### PR TITLE
[feature] Add setting to enable user to create custom symbols

### DIFF
--- a/project/src/settings.js
+++ b/project/src/settings.js
@@ -150,6 +150,8 @@
 	astrology.COLOR_AQUARIUS = "#87CEEB"; 
 	astrology.COLOR_PISCES = "#27AE60"; 	        	
 	astrology.COLORS_SIGNS = [astrology.COLOR_ARIES, astrology.COLOR_TAURUS, astrology.COLOR_GEMINI, astrology.COLOR_CANCER, astrology.COLOR_LEO, astrology.COLOR_VIRGO, astrology.COLOR_LIBRA, astrology.COLOR_SCORPIO, astrology.COLOR_SAGITTARIUS, astrology.COLOR_CAPRICORN, astrology.COLOR_AQUARIUS, astrology.COLOR_PISCES];
+
+	astrology.CUSTOM_SYMBOL_FN = null
 	
 	// 0 degree is on the West 
 	astrology.SHIFT_IN_DEGREES = 180;

--- a/project/src/svg.js
+++ b/project/src/svg.js
@@ -37,16 +37,7 @@
 		context = this;
 	};	
 	
-	/**
-	 * Get a required symbol. 
-	 * 
-	 * @param {String} name
-	 * @param {int} x
-	 * @param {int} y
-	 * 
-	 * @return {SVG g}
-	 */
-	astrology.SVG.prototype.getSymbol = function( name, x, y){
+	astrology.SVG.prototype._getSymbol = function( name, x, y){
 		switch(name) {
 			case astrology.SYMBOL_SUN:		        
 		        return sun( x, y);		        
@@ -182,6 +173,26 @@
 		    	return unknownPoint;	 
 		}			
 	};
+
+
+	/**
+	 * Get a required symbol. 
+	 * 
+	 * @param {String} name
+	 * @param {int} x
+	 * @param {int} y
+	 * 
+	 * @return {SVG g}
+	 */
+	 astrology.SVG.prototype.getSymbol = function( name, x, y){
+		if(astrology.CUSTOM_SYMBOL_FN == null) return astrology.SVG.prototype._getSymbol(name, x, y);
+
+		const symbol = astrology.CUSTOM_SYMBOL_FN(name, x, y, context);
+		if(symbol == null || symbol == undefined) return astrology.SVG.prototype._getSymbol(name, x, y);
+
+		return symbol;
+	}
+
 
 	/**
 	 * Create transparent rectangle. 

--- a/project/test/svg.html
+++ b/project/test/svg.html
@@ -74,6 +74,14 @@
 					assert.true(element.getElementsByTagName("rect").length == 1)
 				});
 			});
+
+			QUnit.test( "should call custom getSymbol function", function( assert ) {
+				window.astrology.SVG("qunit-fixture", 100, 100);
+				let calledFunction = false;
+				window.astrology.CUSTOM_SYMBOL_FN = (symbol, x, y) => calledFunction = symbol == astrology.SYMBOL_URANUS && x == 1 && y == 2;
+				var element = window.astrology.SVG.prototype.getSymbol(astrology.SYMBOL_URANUS, 1, 2);
+				assert.true(calledFunction)
+			});
 		</script>
 	</head>
 	<body>


### PR DESCRIPTION
The settings now will have a new attribute `CUSTOM_SYMBOL_FN` that will receive the same parameters that the internal getSymbol receives and in addition the context element.

### Example creating a custom svg element
```js
function custom_symbol(name, x, y, context) {
  console.log(name, x, y);
  const symbol = document.createElementNS(context.root.namespaceURI, 'circle')
  symbol.setAttribute('cx', x - astrology.SIGNS_STROKE)
  symbol.setAttribute('cy', y - astrology.SIGNS_STROKE)
  symbol.setAttribute('width', '20px')
  symbol.setAttribute('height', '20px')
  symbol.setAttribute('r', '10')
  symbol.setAttribute('fill', 'blue')
  return symbol;
}
window.onload = function () {
  var chart = new astrology.Chart('paper', 600, 600, {CUSTOM_SYMBOL_FN: custom_symbol});  
  chart.radix( data).aspects();
};
```

### Example with image from a external source
```js 
function custom_symbol(name, x, y, context) {
  console.log(name, x, y);
  if(name == astrology.SYMBOL_MARS) return null; // null or undefined will fallback to the defaul implemetation
  const symbol = document.createElementNS(context.root.namespaceURI, 'image')
  symbol.setAttribute('href', 'http://localhost:8080/assets/Sun.svg')
  symbol.setAttribute('x', x - 10)
  symbol.setAttribute('y', y - 10)
  symbol.setAttribute('width', '20px')
  symbol.setAttribute('height', '20px')
  return symbol;
}
window.onload = function () {
  var chart = new astrology.Chart('paper', 600, 600, {CUSTOM_SYMBOL_FN: custom_symbol});
  chart.radix(data).aspects();
};
```

closes #5 