### PR TITLE
Replace `ts-loader` with `esbuild-loader`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/jest": "^27.4.1",
     "@typescript-eslint/eslint-plugin": "^5.53.0",
     "@typescript-eslint/parser": "^5.53.0",
+    "esbuild-loader": "^3.0.1",
     "eslint": "^8.34.0",
     "eslint-config-standard-with-typescript": "^34.0.0",
     "eslint-plugin-import": "^2.27.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,8 +6,7 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
-        use: 'ts-loader',
-        exclude: [/node_modules/, /.test.ts/],
+        loader: 'esbuild-loader',
       },
     ],
   },


### PR DESCRIPTION
resolves #59  

builds in 1/3 of the time, but shows 1 warning

> WARNING in ./project/src/index.ts 4:0-45
> export 'Settings' (reexported as 'Settings') was not found in './settings' (possible exports: default)
> webpack 5.72.0 compiled with 1 warning in 1199 ms