### PR TITLE
Bufix: pass settings to from Radix to AspectCalculator

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "types": "./dist/project/src/index.d.ts",
   "scripts": {
     "test": "jest",
+    "test:w": "jest --watch",
     "test:coverage": "jest --coverage",
     "build": "webpack",
     "build:w": "webpack --watch",

--- a/project/src/radix.test.ts
+++ b/project/src/radix.test.ts
@@ -1,0 +1,42 @@
+import Radix from './radix';
+import SVG from './svg';
+import default_settings from './settings';
+
+describe('Radix', () => {
+  const data = {
+    planets: {
+      Sun: [0],
+      Moon: [90],
+    },
+    cusps: [0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330]
+  };
+
+  it('should draw aspect lines with default colors', () => {
+    document.body.innerHTML = '<div id="chart"></div>';
+    const settings = default_settings;
+    const paper = new SVG('chart', 500, 500, settings);
+    const radix = new Radix(paper, 500, 500, 500, data, settings);
+    radix.aspects();
+
+    const aspectLines = document.querySelectorAll('#chart-astrology-aspects > line');
+    expect(aspectLines[0].getAttribute('stroke')).toBe(default_settings.ASPECTS.square.color);
+  });
+
+  it('should draw aspect lines with custom colors via settings', () => {
+    document.body.innerHTML = '<div id="chart"></div>';
+
+    const settings = {
+      ...default_settings,
+      ASPECTS: {
+        square: { degree: 90, orbit: 10, color: 'purple' },
+      },
+    };
+
+    const paper = new SVG('chart', 500, 500, settings);
+    const radix = new Radix(paper, 500, 500, 500, data, settings);
+    radix.aspects();
+
+    const aspectLines = document.querySelectorAll('#chart-astrology-aspects > line');
+    expect(aspectLines[0].getAttribute('stroke')).toBe('purple');
+  });
+});

--- a/project/src/radix.ts
+++ b/project/src/radix.ts
@@ -327,7 +327,7 @@ class Radix {
   aspects(customAspects?: FormedAspect[] | null): Radix {
     const aspectsList = customAspects != null && Array.isArray(customAspects)
       ? customAspects
-      : new AspectCalculator(this.toPoints).radix(this.data.planets)
+      : new AspectCalculator(this.toPoints, this.settings).radix(this.data.planets)
 
     const universe = this.universe
     const wrapper = getEmptyWrapper(universe, this.paper.root.id + '-' + this.settings.ID_ASPECTS, this.paper.root.id)


### PR DESCRIPTION
Without this, AspectCalculator will always fall back to default settings, in commented line below:

```ts
 class AspectCalculator {
  settings: Partial<Settings>
  toPoints: Points
  context: this
  constructor (toPoints: Points, settings?: Partial<Settings>) {
    if (toPoints == null) {
      throw new Error('Param \'toPoint\' must not be empty.')
    }

    this.settings = settings ?? {}
    this.settings.ASPECTS = settings?.ASPECTS ?? DEFAULT_ASPECTS // <--- `Radix` will always use `DEFAULT_ASPECTS` (before this fix)

    this.toPoints = toPoints

    this.context = this
  }
```