### PR TITLE
chore: upgrade CI to Node 20, fix LICENSE and package.json metadata

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -9,29 +9,29 @@ jobs:
   lint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm ci
       - run: npm run lint
 
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm ci
       - run: npm run test:coverage
 
   build: # sanity check that build does not throw errors
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: npm ci
       - run: npm test
 
@@ -22,10 +22,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2018 Matheus Alves
+Copyright (c) 2015-2025 Arthur Fücher
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "chart",
     "horoscope",
     "zodiac",
-    "ephemetis"
+    "ephemeris"
   ],
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
- Upgrade CI workflows from Node 16 (EOL) to Node 20
- Upgrade actions/checkout and actions/setup-node from v3 to v4
- Fix copyright holder name in LICENSE (was incorrectly copied from another repo at project creation — the actual author and copyright holder has always been Arthur Fücher)
- Update copyright year range to 2015-2025
- Fix typo in package.json keywords: ephemetis → ephemeris

🤖 Generated with [eca](https://eca.dev)