### PR TITLE
CI: add website build job using Node 22

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -35,3 +35,15 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm run build
+
+  build-website: # sanity check that the Astro website builds without errors
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+        working-directory: website
+      - run: npm run build
+        working-directory: website


### PR DESCRIPTION
## Summary

- The Astro version used by the `website/` directory requires Node.js `>=22.12.0`, causing the pipeline to fail with _"Node.js v20.20.1 is not supported by Astro!"_
- Adds a new `build-website` job to `checks.yaml` that installs dependencies and builds the Astro site using **Node 22**
- The existing `lint`, `test`, and `build` jobs are untouched — they target the root library (webpack) and remain on Node 20

## Test plan

- [ ] `build-website` job passes in CI with Node 22
- [ ] Existing `lint`, `test`, and `build` jobs continue to pass on Node 20

🤖 Generated with [eca](https://eca.dev)