### PR TITLE
CI: fix docs-deploy Node version for Astro build

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-library:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -35,6 +35,30 @@ jobs:
 
       - name: Build library
         run: npm run build
+
+      - name: Upload library bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: astrochart-bundle
+          path: dist/astrochart.js
+
+  build-website:
+    needs: build-library
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Download library bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: astrochart-bundle
+          path: dist
 
       - name: Copy bundle to website
         run: cp dist/astrochart.js website/public/astrochart.js
@@ -53,7 +77,7 @@ jobs:
           path: website/dist
 
   deploy:
-    needs: build
+    needs: build-website
     runs-on: ubuntu-22.04
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary

- The `docs-deploy.yml` workflow ran both the library (webpack) build and the Astro website build inside the **same job** under `node-version: 20`, causing Astro to fail: _"Node.js v20 is not supported by Astro! Please upgrade to >=22.12.0"_
- A single GHA job can only run one Node version, so the `build` job has been split into two:
  - **`build-library` (Node 20):** compiles the webpack bundle and uploads it as a workflow artifact
  - **`build-website` (Node 22):** downloads the bundle, copies it to `website/public/`, installs website deps, builds the Astro site, and uploads the Pages artifact
- `deploy` now depends on `build-website` instead of the old `build` job — no other changes

## Test plan

- [ ] `build-library` job passes on Node 20
- [ ] `build-website` job passes on Node 22
- [ ] `deploy` job successfully deploys to GitHub Pages

🤖 Generated with [eca](https://eca.dev)