### PR TITLE
fix(website): prefix astrochart.js path with BASE_URL

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-library:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -35,6 +35,30 @@ jobs:
 
       - name: Build library
         run: npm run build
+
+      - name: Upload library bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: astrochart-bundle
+          path: dist/astrochart.js
+
+  build-website:
+    needs: build-library
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Download library bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: astrochart-bundle
+          path: dist
 
       - name: Copy bundle to website
         run: cp dist/astrochart.js website/public/astrochart.js
@@ -53,7 +77,7 @@ jobs:
           path: website/dist
 
   deploy:
-    needs: build
+    needs: build-website
     runs-on: ubuntu-22.04
     environment:
       name: github-pages

--- a/website/src/components/ChartDemo.astro
+++ b/website/src/components/ChartDemo.astro
@@ -78,7 +78,8 @@ const codeSnippet = getCodeSnippet()
     chartMode: mode,
     chartHeight: height,
     radixData: defaultRadixData,
-    transitData: defaultTransitData
+    transitData: defaultTransitData,
+    baseUrl: import.meta.env.BASE_URL
   }}
 >
   ;(function () {
@@ -112,7 +113,7 @@ const codeSnippet = getCodeSnippet()
     if (window.astrochart) {
       // Library already loaded — init immediately
       initChart()
-    } else if (document.querySelector('script[src="/astrochart.js"]')) {
+    } else if (document.querySelector('script[src="' + baseUrl + 'astrochart.js"]')) {
       // Another instance is already loading the bundle — queue up
       window.__astrochartQueue = window.__astrochartQueue || []
       window.__astrochartQueue.push(initChart)
@@ -122,7 +123,7 @@ const codeSnippet = getCodeSnippet()
       window.__astrochartQueue.push(initChart)
 
       var script = document.createElement('script')
-      script.src = '/astrochart.js'
+      script.src = baseUrl + 'astrochart.js'
       script.onload = function () {
         var queue = window.__astrochartQueue || []
         window.__astrochartQueue = []


### PR DESCRIPTION
## Summary

- `ChartDemo.astro` hard-coded the bundle path as `/astrochart.js` (root-relative)
- With `base: '/AstroChart'` set in `astro.config.mjs`, the file is actually deployed at `/AstroChart/astrochart.js`
- The browser therefore requested `https://astrodraw.github.io/astrochart.js` → **404**

## Fix

Pass `import.meta.env.BASE_URL` into the `is:inline` script via `define:vars` and prefix both usages with it:

```js
// define:vars
baseUrl: import.meta.env.BASE_URL   // resolves to '/AstroChart/'

// querySelector dedup guard
document.querySelector('script[src="' + baseUrl + 'astrochart.js"]')

// dynamic script load
script.src = baseUrl + 'astrochart.js'
// → '/AstroChart/astrochart.js' ✅
```

Astro guarantees `BASE_URL` ends with `/`, so concatenation produces the correct path without any extra slashes.

## Test plan

- [ ] Chart demos render correctly on the deployed site
- [ ] No 404 for `astrochart.js` in the browser network tab
- [ ] Multiple `ChartDemo` instances on the same page still deduplicate the bundle load correctly

🤖 Generated with [eca](https://eca.dev)