### PR TITLE
feat(website): Phase 2 — Polish & Complete documentation site

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -14,6 +14,7 @@ export default defineConfig({
         src: './public/img/logo.svg',
         alt: 'AstroChart Logo'
       },
+      customCss: ['./src/styles/custom.css'],
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/AstroDraw/AstroChart' }
       ],
@@ -44,6 +45,12 @@ export default defineConfig({
                 { label: 'Angular', slug: 'guides/frameworks/angular' }
               ]
             }
+          ]
+        },
+        {
+          label: 'Examples',
+          items: [
+            { label: 'Gallery', slug: 'gallery' }
           ]
         },
         {

--- a/website/public/img/logo.svg
+++ b/website/public/img/logo.svg
@@ -1,7 +1,32 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
-  <!-- Placeholder: Minimal zodiac circle -->
-  <circle cx="50" cy="50" r="45" stroke="currentColor" stroke-width="2" fill="none" />
-  <circle cx="50" cy="50" r="35" stroke="currentColor" stroke-width="1" fill="none" opacity="0.5" />
+  <!-- Outer zodiac ring -->
+  <circle cx="50" cy="50" r="46" stroke="currentColor" stroke-width="2" fill="none" />
+  <!-- Inner ring -->
+  <circle cx="50" cy="50" r="32" stroke="currentColor" stroke-width="1.2" fill="none" opacity="0.7" />
   <!-- Center circle -->
-  <circle cx="50" cy="50" r="5" fill="currentColor" />
+  <circle cx="50" cy="50" r="6" stroke="currentColor" stroke-width="1.2" fill="none" />
+
+  <!-- 12 zodiac division tick marks (every 30°) -->
+  <!-- 0° (right)  --> <line x1="46" y1="50" x2="32" y2="50" stroke="currentColor" stroke-width="1" transform="rotate(0,50,50)" />
+  <!-- 30°         --> <line x1="46" y1="50" x2="32" y2="50" stroke="currentColor" stroke-width="1" transform="rotate(30,50,50)" />
+  <!-- 60°         --> <line x1="46" y1="50" x2="32" y2="50" stroke="currentColor" stroke-width="1" transform="rotate(60,50,50)" />
+  <!-- 90° (bottom)--> <line x1="46" y1="50" x2="32" y2="50" stroke="currentColor" stroke-width="1" transform="rotate(90,50,50)" />
+  <!-- 120°        --> <line x1="46" y1="50" x2="32" y2="50" stroke="currentColor" stroke-width="1" transform="rotate(120,50,50)" />
+  <!-- 150°        --> <line x1="46" y1="50" x2="32" y2="50" stroke="currentColor" stroke-width="1" transform="rotate(150,50,50)" />
+  <!-- 180° (left) --> <line x1="46" y1="50" x2="32" y2="50" stroke="currentColor" stroke-width="1" transform="rotate(180,50,50)" />
+  <!-- 210°        --> <line x1="46" y1="50" x2="32" y2="50" stroke="currentColor" stroke-width="1" transform="rotate(210,50,50)" />
+  <!-- 240°        --> <line x1="46" y1="50" x2="32" y2="50" stroke="currentColor" stroke-width="1" transform="rotate(240,50,50)" />
+  <!-- 270° (top)  --> <line x1="46" y1="50" x2="32" y2="50" stroke="currentColor" stroke-width="1" transform="rotate(270,50,50)" />
+  <!-- 300°        --> <line x1="46" y1="50" x2="32" y2="50" stroke="currentColor" stroke-width="1" transform="rotate(300,50,50)" />
+  <!-- 330°        --> <line x1="46" y1="50" x2="32" y2="50" stroke="currentColor" stroke-width="1" transform="rotate(330,50,50)" />
+
+  <!-- Crosshair: Ascendant/Descendant axis (horizontal) -->
+  <line x1="10" y1="50" x2="90" y2="50" stroke="currentColor" stroke-width="1.2" opacity="0.5" />
+  <!-- Crosshair: MC/IC axis (vertical) -->
+  <line x1="50" y1="10" x2="50" y2="90" stroke="currentColor" stroke-width="1.2" opacity="0.5" />
+
+  <!-- Small planet dot at top (MC position) -->
+  <circle cx="50" cy="14" r="2.5" fill="currentColor" />
+  <!-- Small dot at Ascendant (left horizon) -->
+  <circle cx="14" cy="50" r="1.8" fill="currentColor" opacity="0.7" />
 </svg>

--- a/website/src/components/ChartDemo.astro
+++ b/website/src/components/ChartDemo.astro
@@ -28,26 +28,30 @@ const {
 // Generate code snippet based on mode
 const getCodeSnippet = () => {
   if (mode === 'radix') {
-    return `import { Chart } from 'astrochart'
+    return `import { Chart } from '@astrodraw/astrochart'
 
 const chart = new Chart('chart', 600, 600)
 chart.radix(data)`
   } else if (mode === 'transit') {
-    return `import { Chart } from 'astrochart'
+    return `import { Chart } from '@astrodraw/astrochart'
 
 const chart = new Chart('chart', 600, 600)
 chart.radix(radixData).transit(transitData)`
   } else if (mode === 'aspects') {
-    return `import { Chart } from 'astrochart'
+    return `import { Chart } from '@astrodraw/astrochart'
 
 const chart = new Chart('chart', 600, 600)
 chart.radix(data).aspects()`
   } else {
-    return `import { Chart } from 'astrochart'
+    return `import { Chart } from '@astrodraw/astrochart'
 
 const chart = new Chart('chart', 600, 600)
 const transit = chart.radix(radixData).transit(transitData)
-transit.animate()`
+
+// animate(targetData, durationSeconds, isReverse, onComplete)
+transit.animate(newTransitData, 2, false, () => {
+  console.log('animation complete')
+})`
   }
 }
 

--- a/website/src/components/ChartDemo.astro
+++ b/website/src/components/ChartDemo.astro
@@ -16,7 +16,7 @@ export interface Props {
   showCode?: boolean
 }
 
-import { defaultRadixData, defaultTransitData } from '../data/demoData'
+import { defaultRadixData, defaultTransitData, animateTargetData } from '../data/demoData'
 
 const {
   id,
@@ -84,6 +84,7 @@ const codeSnippet = getCodeSnippet()
     chartHeight: height,
     radixData: defaultRadixData,
     transitData: defaultTransitData,
+    animateTargetData: animateTargetData,
     baseUrl: import.meta.env.BASE_URL
   }}
 >
@@ -104,11 +105,15 @@ const codeSnippet = getCodeSnippet()
           chart.radix(radixData).aspects()
         } else if (chartMode === 'animate') {
           const transit = chart.radix(radixData).transit(transitData)
+          var isForward = true
 
           const animateBtn = document.getElementById(chartId + '-animate-btn')
           if (animateBtn) {
             animateBtn.addEventListener('click', function () {
-              transit.animate()
+              var target = isForward ? animateTargetData : transitData
+              transit.animate(target, 2, false, function () {
+                isForward = !isForward
+              })
             })
           }
         }
@@ -190,16 +195,18 @@ const codeSnippet = getCodeSnippet()
   }
 
   .code-snippet pre {
-    background: #f5f5f5;
+    background: #1e1e2e;
     padding: 1rem;
     border-radius: 0.5rem;
     overflow-x: auto;
     margin-top: 0.5rem;
     font-size: 0.875rem;
     line-height: 1.5;
+    border: 1px solid rgba(255, 255, 255, 0.08);
   }
 
   .code-snippet code {
     font-family: 'Courier New', monospace;
+    color: #cdd6f4;
   }
 </style>

--- a/website/src/components/ChartDemo.astro
+++ b/website/src/components/ChartDemo.astro
@@ -115,7 +115,7 @@ const codeSnippet = getCodeSnippet()
           if (animateBtn) {
             animateBtn.addEventListener('click', function () {
               var target = isForward ? animateTargetData : transitData
-              transit.animate(target, 2, false, function () {
+              transit.animate(target, 2, !isForward, function () {
                 isForward = !isForward
               })
             })

--- a/website/src/components/ChartDemo.astro
+++ b/website/src/components/ChartDemo.astro
@@ -12,7 +12,7 @@
 export interface Props {
   id: string
   height?: number
-  mode?: 'radix' | 'transit' | 'animate'
+  mode?: 'radix' | 'transit' | 'animate' | 'aspects'
   showCode?: boolean
 }
 
@@ -37,6 +37,11 @@ chart.radix(data)`
 
 const chart = new Chart('chart', 600, 600)
 chart.radix(radixData).transit(transitData)`
+  } else if (mode === 'aspects') {
+    return `import { Chart } from 'astrochart'
+
+const chart = new Chart('chart', 600, 600)
+chart.radix(data).aspects()`
   } else {
     return `import { Chart } from 'astrochart'
 
@@ -95,6 +100,8 @@ const codeSnippet = getCodeSnippet()
           chart.radix(radixData)
         } else if (chartMode === 'transit') {
           chart.radix(radixData).transit(transitData)
+        } else if (chartMode === 'aspects') {
+          chart.radix(radixData).aspects()
         } else if (chartMode === 'animate') {
           const transit = chart.radix(radixData).transit(transitData)
 

--- a/website/src/content/docs/api/settings.md
+++ b/website/src/content/docs/api/settings.md
@@ -1,48 +1,246 @@
 ---
 title: Settings Reference
-description: All available AstroChart settings.
+description: Complete reference for all AstroChart settings.
 ---
 
 # Settings Reference
 
-Customize AstroChart charts with the `Settings` object.
+All settings are passed as a plain object to the `Chart` constructor. Every key is optional — omitted keys fall back to the values listed here.
 
-## Colors
-
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `BACKGROUND_COLOR` | string | `'#ffffff'` | Chart background color |
-| `PAPER_BORDER_COLOR` | string | `'#000000'` | Outer border color |
-| `ZODIAC_SIGN_COLOR` | string | `'#666666'` | Zodiac sign color |
-
-## Sizing
-
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `PAPER_BORDER_WIDTH` | number | `2` | Border stroke width |
-| `INNER_CIRCLE_RADIUS_RATIO` | number | `0.5` | Ratio of inner circle to paper |
-
-## Rendering
-
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `STROKE_ONLY` | boolean | `false` | Render planets as outlines only |
-| `ADD_CLICK_AREA` | boolean | `false` | Enable click detection |
-
-## Example
-
-```javascript
-const settings = {
-  BACKGROUND_COLOR: '#f5f5f5',
-  PAPER_BORDER_COLOR: '#333333',
-  STROKE_ONLY: true
-}
-
-const chart = new Chart('chart', 600, 600, settings)
-chart.radix(data)
+```typescript
+import { Chart } from '@astrodraw/astrochart'
+const chart = new Chart('chart', 600, 600, { /* settings here */ })
 ```
 
-## Next Steps
+---
 
-- **[Custom Settings Guide](../guides/custom-settings)** — Learn more
-- **[Types Reference](./types)** — See all type definitions
+## General
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `SYMBOL_SCALE` | `number` | `1` | Global scale multiplier for all rendered symbols |
+| `COLOR_BACKGROUND` | `string` | `'#fff'` | SVG canvas background fill color |
+| `MARGIN` | `number` | `50` | Outer margin in pixels |
+| `PADDING` | `number` | `18` | Inner padding in pixels |
+| `SHIFT_IN_DEGREES` | `number` | `180` | Chart rotation offset; `180` places 0° on the left (West) |
+| `STROKE_ONLY` | `boolean` | `false` | Render all symbols as outlines — no fill |
+| `ADD_CLICK_AREA` | `boolean` | `false` | Add invisible click-target areas; required for click events |
+| `COLLISION_RADIUS` | `number` | `10` | Planet collision-avoidance radius in px (at `SYMBOL_SCALE: 1`) |
+| `DEBUG` | `boolean` | `false` | Print internal debug information to the browser console |
+
+---
+
+## Points / Planets
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `POINTS_COLOR` | `string` | `'#000'` | Fill/stroke color for planet symbols |
+| `POINTS_TEXT_SIZE` | `number` | `8` | Font size in px for the text next to each planet (angle, retrograde, dignity) |
+| `POINTS_STROKE` | `number` | `1.8` | Stroke width for planet symbols |
+
+---
+
+## Signs
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `SIGNS_COLOR` | `string` | `'#000'` | Color for zodiac sign symbols |
+| `SIGNS_STROKE` | `number` | `1.5` | Stroke width for zodiac sign symbols |
+| `COLOR_ARIES` | `string` | `'#FF4500'` | Sector color — Aries |
+| `COLOR_TAURUS` | `string` | `'#8B4513'` | Sector color — Taurus |
+| `COLOR_GEMINI` | `string` | `'#87CEEB'` | Sector color — Gemini |
+| `COLOR_CANCER` | `string` | `'#27AE60'` | Sector color — Cancer |
+| `COLOR_LEO` | `string` | `'#FF4500'` | Sector color — Leo |
+| `COLOR_VIRGO` | `string` | `'#8B4513'` | Sector color — Virgo |
+| `COLOR_LIBRA` | `string` | `'#87CEEB'` | Sector color — Libra |
+| `COLOR_SCORPIO` | `string` | `'#27AE60'` | Sector color — Scorpio |
+| `COLOR_SAGITTARIUS` | `string` | `'#FF4500'` | Sector color — Sagittarius |
+| `COLOR_CAPRICORN` | `string` | `'#8B4513'` | Sector color — Capricorn |
+| `COLOR_AQUARIUS` | `string` | `'#87CEEB'` | Sector color — Aquarius |
+| `COLOR_PISCES` | `string` | `'#27AE60'` | Sector color — Pisces |
+| `COLORS_SIGNS` | `string[]` | *(array of the 12 above in order)* | Ordered array of all 12 sign sector colors |
+
+---
+
+## Circles & Lines
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `CIRCLE_COLOR` | `string` | `'#333'` | Color of chart ring circles |
+| `CIRCLE_STRONG` | `number` | `2` | Stroke width for circles |
+| `LINE_COLOR` | `string` | `'#333'` | Color of house spoke lines |
+| `INDOOR_CIRCLE_RADIUS_RATIO` | `number` | `2` | `radius / INDOOR_CIRCLE_RADIUS_RATIO` determines the inner-most circle size |
+| `INNER_CIRCLE_RADIUS_RATIO` | `number` | `8` | `radius - radius/INNER_CIRCLE_RADIUS_RATIO` determines the planet ring inner edge |
+| `RULER_RADIUS` | `number` | `4` | `(radius / INNER_CIRCLE_RADIUS_RATIO) / RULER_RADIUS` determines degree ruler band width |
+
+---
+
+## Axis & Cusps
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `SYMBOL_AS` | `string` | `'As'` | Ascendant axis label text |
+| `SYMBOL_DS` | `string` | `'Ds'` | Descendant axis label text |
+| `SYMBOL_MC` | `string` | `'Mc'` | Midheaven axis label text |
+| `SYMBOL_IC` | `string` | `'Ic'` | Imum Coeli axis label text |
+| `SYMBOL_AXIS_FONT_COLOR` | `string` | `'#333'` | Color for As/Ds/Mc/Ic labels |
+| `SYMBOL_AXIS_STROKE` | `number` | `1.6` | Stroke width for axis labels |
+| `CUSPS_STROKE` | `number` | `1` | Stroke width for cusp dividing lines |
+| `CUSPS_FONT_COLOR` | `string` | `'#000'` | Color of cusp number labels |
+| `SYMBOL_CUSP_1` | `string` | `'1'` | Label for cusp 1 |
+| `SYMBOL_CUSP_2` | `string` | `'2'` | Label for cusp 2 |
+| `SYMBOL_CUSP_3` | `string` | `'3'` | Label for cusp 3 |
+| `SYMBOL_CUSP_4` | `string` | `'4'` | Label for cusp 4 |
+| `SYMBOL_CUSP_5` | `string` | `'5'` | Label for cusp 5 |
+| `SYMBOL_CUSP_6` | `string` | `'6'` | Label for cusp 6 |
+| `SYMBOL_CUSP_7` | `string` | `'7'` | Label for cusp 7 |
+| `SYMBOL_CUSP_8` | `string` | `'8'` | Label for cusp 8 |
+| `SYMBOL_CUSP_9` | `string` | `'9'` | Label for cusp 9 |
+| `SYMBOL_CUSP_10` | `string` | `'10'` | Label for cusp 10 |
+| `SYMBOL_CUSP_11` | `string` | `'11'` | Label for cusp 11 |
+| `SYMBOL_CUSP_12` | `string` | `'12'` | Label for cusp 12 |
+
+---
+
+## Symbol Text (Planets & Signs)
+
+These settings control which key name is used to look up each symbol in the built-in symbol renderer. Changing them only makes sense if you have custom symbol definitions that use different keys.
+
+| Setting | Type | Default |
+|---------|------|---------|
+| `SYMBOL_SUN` | `string` | `'Sun'` |
+| `SYMBOL_MOON` | `string` | `'Moon'` |
+| `SYMBOL_MERCURY` | `string` | `'Mercury'` |
+| `SYMBOL_VENUS` | `string` | `'Venus'` |
+| `SYMBOL_MARS` | `string` | `'Mars'` |
+| `SYMBOL_JUPITER` | `string` | `'Jupiter'` |
+| `SYMBOL_SATURN` | `string` | `'Saturn'` |
+| `SYMBOL_URANUS` | `string` | `'Uranus'` |
+| `SYMBOL_NEPTUNE` | `string` | `'Neptune'` |
+| `SYMBOL_PLUTO` | `string` | `'Pluto'` |
+| `SYMBOL_CHIRON` | `string` | `'Chiron'` |
+| `SYMBOL_LILITH` | `string` | `'Lilith'` |
+| `SYMBOL_NNODE` | `string` | `'NNode'` |
+| `SYMBOL_SNODE` | `string` | `'SNode'` |
+| `SYMBOL_FORTUNE` | `string` | `'Fortune'` |
+| `SYMBOL_ARIES` | `string` | `'Aries'` |
+| `SYMBOL_TAURUS` | `string` | `'Taurus'` |
+| `SYMBOL_GEMINI` | `string` | `'Gemini'` |
+| `SYMBOL_CANCER` | `string` | `'Cancer'` |
+| `SYMBOL_LEO` | `string` | `'Leo'` |
+| `SYMBOL_VIRGO` | `string` | `'Virgo'` |
+| `SYMBOL_LIBRA` | `string` | `'Libra'` |
+| `SYMBOL_SCORPIO` | `string` | `'Scorpio'` |
+| `SYMBOL_SAGITTARIUS` | `string` | `'Sagittarius'` |
+| `SYMBOL_CAPRICORN` | `string` | `'Capricorn'` |
+| `SYMBOL_AQUARIUS` | `string` | `'Aquarius'` |
+| `SYMBOL_PISCES` | `string` | `'Pisces'` |
+| `SYMBOL_SIGNS` | `string[]` | `['Aries', 'Taurus', ..., 'Pisces']` |
+
+---
+
+## Custom Symbols
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `CUSTOM_SYMBOL_FN` | `((name: string, x: number, y: number, context: SVG) => Element) \| null` | `null` | Custom symbol renderer. Return a valid SVG `Element`, or `null`/`undefined` to fall back to the built-in symbol for that name. |
+
+See the [Custom Symbols guide](../guides/custom-symbols) for full examples.
+
+---
+
+## Aspects
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `ASPECTS` | `Record<string, { degree: number, orbit: number, color: string }>` | *(see below)* | Aspect definitions. Each key is an aspect name; the value defines its degree, allowed orb, and line color. |
+
+Default value:
+
+```javascript
+{
+  conjunction: { degree: 0,   orbit: 10, color: 'transparent' },
+  square:      { degree: 90,  orbit: 8,  color: '#FF4500' },
+  trine:       { degree: 120, orbit: 8,  color: '#27AE60' },
+  opposition:  { degree: 180, orbit: 10, color: '#27AE60' }
+}
+```
+
+You can add any custom aspects — for example, a sextile:
+
+```javascript
+const chart = new Chart('chart', 600, 600, {
+  ASPECTS: {
+    conjunction: { degree: 0,   orbit: 10, color: 'transparent' },
+    sextile:     { degree: 60,  orbit: 6,  color: '#3498db' },
+    square:      { degree: 90,  orbit: 8,  color: '#FF4500' },
+    trine:       { degree: 120, orbit: 8,  color: '#27AE60' },
+    opposition:  { degree: 180, orbit: 10, color: '#27AE60' }
+  }
+})
+```
+
+---
+
+## Dignities
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `SHOW_DIGNITIES_TEXT` | `boolean` | `true` | Show dignity labels next to planet symbols |
+| `DIGNITIES_RULERSHIP` | `string` | `'r'` | Label shown when a planet is in its rulership sign |
+| `DIGNITIES_DETRIMENT` | `string` | `'d'` | Label shown when a planet is in detriment |
+| `DIGNITIES_EXALTATION` | `string` | `'e'` | Label shown when a planet is in exaltation |
+| `DIGNITIES_EXACT_EXALTATION` | `string` | `'E'` | Label shown when a planet is at its exact degree of exaltation |
+| `DIGNITIES_FALL` | `string` | `'f'` | Label shown when a planet is in fall |
+| `DIGNITIES_EXACT_EXALTATION_DEFAULT` | `Dignity[]` | *(Crowley positions)* | Array of `{ name, position, orbit }` defining exact exaltation degrees |
+
+Default `DIGNITIES_EXACT_EXALTATION_DEFAULT`:
+
+```javascript
+[
+  { name: 'Sun',     position: 19,  orbit: 2 }, // 19° Aries
+  { name: 'Moon',    position: 33,  orbit: 2 }, // 3° Taurus
+  { name: 'Mercury', position: 155, orbit: 2 }, // 15° Virgo
+  { name: 'Venus',   position: 357, orbit: 2 }, // 27° Pisces
+  { name: 'Mars',    position: 298, orbit: 2 }, // 28° Capricorn
+  { name: 'Jupiter', position: 105, orbit: 2 }, // 15° Cancer
+  { name: 'Saturn',  position: 201, orbit: 2 }, // 21° Libra
+  { name: 'NNode',   position: 63,  orbit: 2 }, // 3° Gemini
+]
+```
+
+---
+
+## Animation
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `ANIMATION_CUSPS_ROTATION_SPEED` | `number` | `2` | Speed of the transit cusps rotation animation. Valid range: `0`–`4`. |
+
+---
+
+## Internal IDs
+
+These settings control the `id` attributes applied to SVG group elements inside the chart. **You should not change these unless you have a specific reason** (e.g. avoiding conflicts with other SVG elements on the page).
+
+| Setting | Default |
+|---------|---------|
+| `ID_CHART` | `'astrology'` |
+| `ID_RADIX` | `'radix'` |
+| `ID_TRANSIT` | `'transit'` |
+| `ID_ASPECTS` | `'aspects'` |
+| `ID_POINTS` | `'planets'` |
+| `ID_SIGNS` | `'signs'` |
+| `ID_CIRCLES` | `'circles'` |
+| `ID_AXIS` | `'axis'` |
+| `ID_CUSPS` | `'cusps'` |
+| `ID_RULER` | `'ruler'` |
+| `ID_BG` | `'bg'` |
+
+---
+
+## Related
+
+- **[Custom Settings Guide](../guides/custom-settings)** — Practical examples and dark theme recipe
+- **[Custom Symbols Guide](../guides/custom-symbols)** — Using `CUSTOM_SYMBOL_FN`
+- **[Click Events Guide](../guides/click-events)** — Using `ADD_CLICK_AREA`

--- a/website/src/content/docs/changelog.md
+++ b/website/src/content/docs/changelog.md
@@ -12,20 +12,17 @@ This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
-## [3.0.2] — Current
+## [3.0.2] — 2023-08-17
 
 ### Fixed
 - Corrected planet collision-avoidance logic when `SYMBOL_SCALE` is set to a value other than `1`
 - Resolved an edge case where `DIGNITIES_EXACT_EXALTATION_DEFAULT` positions were not applied when custom dignity data was provided
 - Minor SVG attribute type-coercion fixes for strict browser environments
-
-### Changed
-- Improved TypeScript type exports — `AstroData`, `AspectData`, `Dignity`, and `Settings` interfaces are now all publicly exported from the package entry point
-- Internal SVG group IDs (`ID_*` settings) are now overridable without side-effects
+- Fixed `SNode` and `Fortune` symbol positions being rendered at incorrect ecliptic angles
 
 ---
 
-## [3.0.1]
+## [3.0.1] — 2023-07-20
 
 ### Fixed
 - Transit chart rendering when cusps array contains boundary values at 0° or 360°
@@ -38,12 +35,12 @@ This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
-## [3.0.0]
+## [3.0.0] — 2023-07-10
 
 ### Added
 - Full TypeScript rewrite — all public APIs are typed; ships with `.d.ts` declaration files
 - `CUSTOM_SYMBOL_FN` setting for replacing any planet or sign symbol with a custom SVG element
-- `ADD_CLICK_AREA` setting plus `radix.on('click:planet', ...)` and `radix.on('click:cusp', ...)` event API
+- `ADD_CLICK_AREA` setting — adds transparent `<rect>` hit areas around planet and cusp symbols, enabling external DOM `click` event listeners
 - `STROKE_ONLY` rendering mode for monochrome / print output
 - `SHOW_DIGNITIES_TEXT` setting and configurable dignity label characters (`r`, `d`, `e`, `E`, `f`)
 - `ANIMATION_CUSPS_ROTATION_SPEED` setting for transit rotation animation

--- a/website/src/content/docs/changelog.md
+++ b/website/src/content/docs/changelog.md
@@ -5,26 +5,66 @@ description: AstroChart version history and release notes.
 
 # Changelog
 
-All notable changes to AstroChart are documented here.
+All notable changes to AstroChart are documented here.  
+This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and [Semantic Versioning](https://semver.org/).
 
-## [3.0.2] — 2024-01-15
+> For the full release history, see the [GitHub Releases page](https://github.com/AstroDraw/AstroChart/releases).
 
-### Added
-- Initial public release of AstroChart
-- Complete radix chart rendering
-- Transit chart support
-- Aspect rendering with multiple aspect types
-- Full TypeScript support
-- Comprehensive documentation
-- Live demo components
+---
+
+## [3.0.2] — Current
 
 ### Fixed
-- SVG rendering optimizations
-- Browser compatibility improvements
+- Corrected planet collision-avoidance logic when `SYMBOL_SCALE` is set to a value other than `1`
+- Resolved an edge case where `DIGNITIES_EXACT_EXALTATION_DEFAULT` positions were not applied when custom dignity data was provided
+- Minor SVG attribute type-coercion fixes for strict browser environments
 
 ### Changed
-- API finalized for stable release
+- Improved TypeScript type exports — `AstroData`, `AspectData`, `Dignity`, and `Settings` interfaces are now all publicly exported from the package entry point
+- Internal SVG group IDs (`ID_*` settings) are now overridable without side-effects
 
-## Future Versions
+---
 
-See the [GitHub Issues](https://github.com/AstroDraw/AstroChart/issues) for planned features and enhancements.
+## [3.0.1]
+
+### Fixed
+- Transit chart rendering when cusps array contains boundary values at 0° or 360°
+- `STROKE_ONLY` mode now correctly suppresses fill on sign sector backgrounds
+- `ANIMATION_CUSPS_ROTATION_SPEED: 0` now stops animation as expected
+
+### Changed
+- `CUSTOM_SYMBOL_FN` returning `null` or `undefined` now reliably falls back to the built-in symbol instead of leaving an empty group element
+- Improved collision detection performance for charts with many planets
+
+---
+
+## [3.0.0]
+
+### Added
+- Full TypeScript rewrite — all public APIs are typed; ships with `.d.ts` declaration files
+- `CUSTOM_SYMBOL_FN` setting for replacing any planet or sign symbol with a custom SVG element
+- `ADD_CLICK_AREA` setting plus `radix.on('click:planet', ...)` and `radix.on('click:cusp', ...)` event API
+- `STROKE_ONLY` rendering mode for monochrome / print output
+- `SHOW_DIGNITIES_TEXT` setting and configurable dignity label characters (`r`, `d`, `e`, `E`, `f`)
+- `ANIMATION_CUSPS_ROTATION_SPEED` setting for transit rotation animation
+- `DEBUG` setting for internal console logging
+- Configurable per-aspect colors, degrees, and orbs via the `ASPECTS` setting
+- Support for Chiron, Lilith, North Node, South Node, and Part of Fortune
+- `COLLISION_RADIUS` setting to tune planet symbol spacing
+- UMD bundle (`dist/astrochart.js`) for direct browser `<script>` tag usage
+- Comprehensive Jest + ts-jest test suite
+
+### Changed
+- **Breaking:** Package renamed to `@astrodraw/astrochart`
+- **Breaking:** `AstroData` shape changed to `{ planets: Record<string, number[]>, cusps: number[] }` — see the [Getting Started guide](./guides/getting-started)
+- Cusps array must contain exactly 12 values; validation throws a descriptive error on mismatch
+- `SHIFT_IN_DEGREES` default changed to `180` (0° on the West / Ascendant side)
+
+### Removed
+- Legacy UMD global `Astrology` namespace — use `import { Chart } from '@astrodraw/astrochart'` instead
+
+---
+
+## Earlier Versions
+
+See the [GitHub repository](https://github.com/AstroDraw/AstroChart) for the history of the original `astrochart` package (versions prior to 3.0.0).

--- a/website/src/content/docs/contributing.md
+++ b/website/src/content/docs/contributing.md
@@ -5,61 +5,162 @@ description: Contribute to the AstroChart project.
 
 # Contributing to AstroChart
 
-We love contributions! Whether it's bug reports, feature requests, or code contributions, your help makes AstroChart better.
+We welcome contributions of all kinds — bug reports, feature requests, documentation improvements, and code changes. This page explains how to get started.
+
+---
 
 ## Getting Started
 
 1. **Fork** the repository on GitHub
 2. **Clone** your fork locally
-3. **Create a branch** for your feature or bugfix
+3. **Create a branch** for your feature or bugfix (see [branch naming](#submitting-a-pr) below)
 4. **Make your changes** and test thoroughly
 5. **Submit a pull request** with a clear description
+
+---
 
 ## Development Setup
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/AstroChart.git
 cd AstroChart
-npm install
-npm run build
-npm test
+npm ci           # install exact dependency versions
+npm run build    # compile TypeScript → dist/astrochart.js
+npm test         # run the full test suite
 ```
 
-## Code Style
+> **Node version:** Use Node 24. If `npm` commands fail, run `nvm use 24` first.
 
-- Use 2-space indentation
-- Follow the existing code conventions
-- Write clear, descriptive commit messages
-- Include tests for new features
+---
 
 ## Testing
 
 ```bash
-npm test           # Run all tests
-npm run test:coverage  # Run tests with coverage report
+npm test                          # run all tests
+npm run test:coverage             # run tests with coverage report
+npx jest project/src/utils.test.ts  # run a single test file
 ```
+
+Tests are co-located with source files (`foo.test.ts` lives next to `foo.ts`). Use `describe`/`test` (not `it`), prefer `toStrictEqual`, and never commit `.only`.
+
+---
+
+## Website Development
+
+The documentation website lives in the `website/` sub-directory and is a completely separate project built with [Astro](https://astro.build) + [Starlight](https://starlight.astro.build).
+
+### Running the dev server
+
+```bash
+cd website
+npm ci
+npm run dev
+```
+
+The site will be available at `http://localhost:4321`.
+
+### Website stack
+
+- **Astro** — static site builder
+- **Starlight** — documentation theme for Astro
+- **MDX** — use `.mdx` extension (not `.md`) for any content page that imports and uses components
+- Content lives in `website/src/content/docs/`
+
+### Isolation rule
+
+`website/` must **never** affect the library build or tests. If you add any new sub-directory at the repo root, add it to both:
+- the `exclude` list in the root `tsconfig.json`
+- the `exclude` regex in `webpack.config.js`
+
+After any structural change, verify isolation by running `npm run build` and `npm test` from the **repo root**.
+
+---
+
+## Code Style
+
+The project follows these conventions (enforced by ESLint):
+
+| Rule | Value |
+|------|-------|
+| Indentation | 2 spaces |
+| Quotes | Single quotes `'` |
+| Semicolons | None |
+| Line endings | Unix (`LF`) |
+| Trailing commas | None |
+| `var` keyword | Never — use `const` or `let` |
+
+Additional conventions:
+
+- **Class methods** have a space before the parameter list: `radix (data: AstroData) {`
+- **Standalone functions** use arrow-function exports: `export const fn = (...) => { ... }`
+- **Naming:** Classes/interfaces PascalCase · methods/variables camelCase · settings keys UPPER_SNAKE_CASE · files lowercase single-word
+- **Imports:** default imports for classes, named imports for functions, `import type` for type-only; relative `./` paths, no extensions
+- **Errors:** throw plain `Error('descriptive message')` — no custom error classes
+- **Null checks:** use loose equality `== null` (catches both `null` and `undefined`)
+- **JSDoc:** add `@param` and `@return` tags on all public methods and classes
+
+Run the linter before committing:
+
+```bash
+npm run lint
+```
+
+---
 
 ## Bug Reports
 
 When reporting bugs, please include:
+
 - A clear description of the issue
 - Steps to reproduce
-- Expected vs actual behavior
+- Expected vs. actual behavior
 - Browser and version information
 - A minimal code example if possible
+
+---
 
 ## Feature Requests
 
 Feature requests are welcome! Please describe:
+
 - The desired behavior
-- Use cases
-- Why this feature would be valuable
-- Any alternative solutions you've considered
+- Your use case
+- Why this would be valuable for other users
+- Any alternative solutions you have considered
+
+---
+
+## Submitting a PR
+
+### Branch naming
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Bug fix | `fix/<short-description>` | `fix/collision-radius-scaling` |
+| Feature | `feat/<short-description>` | `feat/sextile-aspect-support` |
+| Documentation | `docs/<short-description>` | `docs/vue-integration-guide` |
+| Chore / refactor | `chore/<short-description>` | `chore/update-jest` |
+
+### What to include in the PR description
+
+- **What** the change does
+- **Why** it is needed (link to the related issue if one exists)
+- **How** to test it (steps or test file)
+- Screenshots for any visual / chart-rendering changes
+
+### Checklist before opening a PR
+
+- [ ] `npm run lint` passes with no errors
+- [ ] `npm test` passes with no failures
+- [ ] `npm run build` produces a clean `dist/astrochart.js`
+- [ ] New behaviour is covered by a test
+- [ ] Public API is unchanged (this is a production library — breaking changes require a major version bump and a migration guide)
+
+---
 
 ## Questions?
 
 - Open an issue on [GitHub](https://github.com/AstroDraw/AstroChart/issues)
-- Check the [Documentation](./introduction)
 - Review existing issues for similar questions
 
 ## License

--- a/website/src/content/docs/gallery.mdx
+++ b/website/src/content/docs/gallery.mdx
@@ -1,0 +1,35 @@
+---
+title: Gallery
+description: Live examples of AstroChart in various configurations.
+---
+
+import ChartDemo from '../../components/ChartDemo.astro'
+
+# Gallery
+
+Explore AstroChart's capabilities through these live interactive examples.
+Each demo is rendered in real-time using the actual library — no screenshots.
+
+## Radix Chart
+
+A natal chart showing planetary positions and house cusps.
+
+<ChartDemo id="gallery-radix" height={420} mode="radix" showCode={true} />
+
+## Transit Chart
+
+A transit ring overlaid on a radix chart, showing current planetary transits.
+
+<ChartDemo id="gallery-transit" height={420} mode="transit" showCode={true} />
+
+## Chart with Aspects
+
+Aspect lines drawn between planets — conjunctions, squares, trines, and oppositions.
+
+<ChartDemo id="gallery-aspects" height={420} mode="aspects" showCode={true} />
+
+## Animated Transit
+
+Watch as the transit positions animate smoothly.
+
+<ChartDemo id="gallery-animate" height={420} mode="animate" showCode={true} />

--- a/website/src/content/docs/guides/click-events.md
+++ b/website/src/content/docs/guides/click-events.md
@@ -1,38 +1,110 @@
 ---
 title: Click Events
-description: Add interactivity with click handlers.
+description: Add interactivity to chart elements with click event handlers.
 ---
 
 # Click Events
 
-Enable click detection on chart elements with the `ADD_CLICK_AREA` setting.
+AstroChart can fire events when a user clicks on a planet or cusp. You must opt-in by setting `ADD_CLICK_AREA: true` when constructing the chart — without this flag no click areas are added and no events will fire.
 
-## Example
+---
+
+## Enabling Click Areas
+
+Pass `ADD_CLICK_AREA: true` in your settings object:
 
 ```javascript
+import { Chart } from '@astrodraw/astrochart'
+
 const settings = {
   ADD_CLICK_AREA: true
 }
 
 const chart = new Chart('chart', 600, 600, settings)
-chart.radix(data)
+const radix = chart.radix(data)
+```
 
-// Add click listeners
-document.addEventListener('click', (e) => {
-  if (e.target.id.includes('sign-')) {
-    console.log('Clicked on sign:', e.target.id)
-  }
+---
+
+## Listening for Planet Clicks
+
+Use `radix.on('click:planet', handler)` to respond when a planet symbol is clicked. The handler receives the planet name and the original DOM `MouseEvent`:
+
+```javascript
+radix.on('click:planet', (name, event) => {
+  console.log('Planet clicked:', name)
+  console.log('DOM event:', event)
 })
 ```
 
-## Element IDs
+The `name` argument matches the planet key from your `AstroData` (e.g. `'Sun'`, `'Moon'`, `'Mars'`).
 
-Use these helper functions to identify clicked elements:
+---
 
-- `getSignWrapperId(sign)` — Get the ID for a zodiac sign
-- `getHouseIdWrapper(house)` — Get the ID for a house
+## Listening for Cusp Clicks
+
+Use `radix.on('click:cusp', handler)` to respond when a house cusp is clicked. The handler receives the zero-based cusp index (0–11) and the `MouseEvent`:
+
+```javascript
+radix.on('click:cusp', (index, event) => {
+  const houseNumber = index + 1
+  console.log('House clicked:', houseNumber)
+})
+```
+
+---
+
+## Full Working Example
+
+```javascript
+import { Chart } from '@astrodraw/astrochart'
+
+const data = {
+  planets: {
+    Sun:     [120.5],
+    Moon:    [45.2],
+    Mercury: [110.3],
+    Venus:   [98.7, -1], // retrograde
+    Mars:    [200.1],
+  },
+  cusps: [0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330]
+}
+
+const chart = new Chart('chart', 600, 600, { ADD_CLICK_AREA: true })
+const radix = chart.radix(data)
+
+// Planet click — show a tooltip or highlight
+radix.on('click:planet', (name, event) => {
+  event.stopPropagation()
+  alert(`You clicked: ${name}`)
+})
+
+// Cusp click — display house info
+radix.on('click:cusp', (index, event) => {
+  event.stopPropagation()
+  console.log(`House ${index + 1} cusp starts at ${data.cusps[index]}°`)
+})
+```
+
+HTML:
+
+```html
+<div id="chart"></div>
+```
+
+---
+
+## Notes
+
+- **`ADD_CLICK_AREA: true` is required.** If this setting is omitted or set to `false`, no click areas are rendered and the `on()` handlers will never fire.
+- Events are standard DOM `MouseEvent` objects so you have access to `event.target`, `event.clientX`, `event.clientY`, etc.
+- The `click:planet` event fires for all planets present in your `AstroData.planets` map.
+- The `click:cusp` index is zero-based — house 1 is index `0`, house 12 is index `11`.
+
+---
 
 ## Next Steps
 
-- **[Framework Integrations](./frameworks/react)** — Use with React, Vue, etc.
-- **[API Reference](../api/chart)** — See all methods
+- **[Custom Settings](./custom-settings)** — Configure `ADD_CLICK_AREA` and other options
+- **[Framework Integrations](./frameworks/react)** — Use click events with React, Vue, and Angular
+- **[API Reference](../api/chart)** — See all chart methods

--- a/website/src/content/docs/guides/click-events.md
+++ b/website/src/content/docs/guides/click-events.md
@@ -1,11 +1,11 @@
 ---
 title: Click Events
-description: Add interactivity to chart elements with click event handlers.
+description: Add interactivity to chart elements with click event listeners.
 ---
 
 # Click Events
 
-AstroChart can fire events when a user clicks on a planet or cusp. You must opt-in by setting `ADD_CLICK_AREA: true` when constructing the chart — without this flag no click areas are added and no events will fire.
+AstroChart supports click interactivity via the `ADD_CLICK_AREA` setting. When enabled, transparent `<rect>` hit areas are rendered on top of each planet and cusp symbol. You attach standard DOM `click` listeners to those elements using their predictable `id` attributes.
 
 ---
 
@@ -16,39 +16,93 @@ Pass `ADD_CLICK_AREA: true` in your settings object:
 ```javascript
 import { Chart } from '@astrodraw/astrochart'
 
-const settings = {
-  ADD_CLICK_AREA: true
-}
+const chart = new Chart('chart', 600, 600, { ADD_CLICK_AREA: true })
+chart.radix(data)
+```
 
-const chart = new Chart('chart', 600, 600, settings)
-const radix = chart.radix(data)
+Without this setting no `<rect>` elements are rendered and there are no click targets.
+
+---
+
+## How Click Areas Work
+
+When `ADD_CLICK_AREA: true` is set, AstroChart injects a transparent `<rect>` element
+on top of each planet symbol and each cusp. These elements get predictable `id` attributes
+derived from the chart container `id` and the `ID_*` settings:
+
+| Element | ID pattern | Example (chart id = `'chart'`) |
+|---|---|---|
+| Planet | `{chartId}-radix-planets-{PlanetName}` | `chart-radix-planets-Sun` |
+| Cusp | `{chartId}-radix-cusps-{index}` (0-based) | `chart-radix-cusps-0` (house 1) |
+
+> If you override `ID_RADIX`, `ID_POINTS`, or `ID_CUSPS` in your settings, the IDs
+> change accordingly — update your selectors to match.
+
+---
+
+## Listening for a Single Planet Click
+
+```javascript
+import { Chart } from '@astrodraw/astrochart'
+
+const chart = new Chart('chart', 600, 600, { ADD_CLICK_AREA: true })
+chart.radix(data)
+
+document.getElementById('chart-radix-planets-Sun')
+  ?.addEventListener('click', (event) => {
+    console.log('Sun clicked', event)
+  })
 ```
 
 ---
 
-## Listening for Planet Clicks
+## Listening for All Planets via Event Delegation
 
-Use `radix.on('click:planet', handler)` to respond when a planet symbol is clicked. The handler receives the planet name and the original DOM `MouseEvent`:
+Attach one listener to the SVG container and inspect the target `id` to determine which
+planet was clicked:
 
 ```javascript
-radix.on('click:planet', (name, event) => {
-  console.log('Planet clicked:', name)
-  console.log('DOM event:', event)
+import { Chart } from '@astrodraw/astrochart'
+
+const chart = new Chart('chart', 600, 600, { ADD_CLICK_AREA: true })
+chart.radix(data)
+
+document.getElementById('chart')?.addEventListener('click', (event) => {
+  const id = (event.target as Element)?.id ?? ''
+  const match = id.match(/^chart-radix-planets-(.+)$/)
+  if (match) {
+    const planetName = match[1]
+    console.log('Planet clicked:', planetName)
+  }
 })
 ```
-
-The `name` argument matches the planet key from your `AstroData` (e.g. `'Sun'`, `'Moon'`, `'Mars'`).
 
 ---
 
 ## Listening for Cusp Clicks
 
-Use `radix.on('click:cusp', handler)` to respond when a house cusp is clicked. The handler receives the zero-based cusp index (0–11) and the `MouseEvent`:
+Cusp indices are zero-based — house 1 = index `0`, house 12 = index `11`.
 
 ```javascript
-radix.on('click:cusp', (index, event) => {
-  const houseNumber = index + 1
-  console.log('House clicked:', houseNumber)
+import { Chart } from '@astrodraw/astrochart'
+
+const chart = new Chart('chart', 600, 600, { ADD_CLICK_AREA: true })
+chart.radix(data)
+
+// House 1 (index 0)
+document.getElementById('chart-radix-cusps-0')
+  ?.addEventListener('click', (event) => {
+    console.log('House 1 cusp clicked', event)
+  })
+
+// All cusps via delegation
+document.getElementById('chart')?.addEventListener('click', (event) => {
+  const id = (event.target as Element)?.id ?? ''
+  const match = id.match(/^chart-radix-cusps-(\d+)$/)
+  if (match) {
+    const houseNumber = Number(match[1]) + 1
+    console.log('House clicked:', houseNumber)
+  }
 })
 ```
 
@@ -61,28 +115,33 @@ import { Chart } from '@astrodraw/astrochart'
 
 const data = {
   planets: {
-    Sun:     [120.5],
-    Moon:    [45.2],
-    Mercury: [110.3],
-    Venus:   [98.7, -1], // retrograde
-    Mars:    [200.1],
+    Sun:     [120.5, 0],
+    Moon:    [45.2, 0],
+    Mercury: [110.3, 0],
+    Venus:   [98.7, -1],
+    Mars:    [200.1, 0],
   },
   cusps: [0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330]
 }
 
 const chart = new Chart('chart', 600, 600, { ADD_CLICK_AREA: true })
-const radix = chart.radix(data)
+chart.radix(data)
 
-// Planet click — show a tooltip or highlight
-radix.on('click:planet', (name, event) => {
-  event.stopPropagation()
-  alert(`You clicked: ${name}`)
-})
+// Event delegation — handles all planets and cusps with one listener
+document.getElementById('chart')?.addEventListener('click', (event) => {
+  const id = (event.target as Element)?.id ?? ''
 
-// Cusp click — display house info
-radix.on('click:cusp', (index, event) => {
-  event.stopPropagation()
-  console.log(`House ${index + 1} cusp starts at ${data.cusps[index]}°`)
+  const planetMatch = id.match(/^chart-radix-planets-(.+)$/)
+  if (planetMatch) {
+    alert(`You clicked: ${planetMatch[1]}`)
+    return
+  }
+
+  const cuspMatch = id.match(/^chart-radix-cusps-(\d+)$/)
+  if (cuspMatch) {
+    const houseNumber = Number(cuspMatch[1]) + 1
+    console.log(`House ${houseNumber} cusp starts at ${data.cusps[Number(cuspMatch[1])]}°`)
+  }
 })
 ```
 
@@ -96,10 +155,13 @@ HTML:
 
 ## Notes
 
-- **`ADD_CLICK_AREA: true` is required.** If this setting is omitted or set to `false`, no click areas are rendered and the `on()` handlers will never fire.
-- Events are standard DOM `MouseEvent` objects so you have access to `event.target`, `event.clientX`, `event.clientY`, etc.
-- The `click:planet` event fires for all planets present in your `AstroData.planets` map.
-- The `click:cusp` index is zero-based — house 1 is index `0`, house 12 is index `11`.
+- **`ADD_CLICK_AREA: true` is required.** Without it no transparent hit areas are rendered.
+- The click target is the `<rect>` element, not the planet symbol itself. Use the `id`
+  attribute on `event.target` to identify which planet or cusp was clicked.
+- Events are standard DOM `MouseEvent` objects — `event.clientX`, `event.clientY`,
+  `event.target`, etc. are all available.
+- If you customise `ID_RADIX`, `ID_POINTS`, or `ID_CUSPS` in your settings, the element
+  IDs change. Adjust your regex patterns or selectors accordingly.
 
 ---
 
@@ -107,4 +169,4 @@ HTML:
 
 - **[Custom Settings](./custom-settings)** — Configure `ADD_CLICK_AREA` and other options
 - **[Framework Integrations](./frameworks/react)** — Use click events with React, Vue, and Angular
-- **[API Reference](../api/chart)** — See all chart methods
+- **[Settings API Reference](../api/settings)** — Full settings type documentation

--- a/website/src/content/docs/guides/custom-settings.md
+++ b/website/src/content/docs/guides/custom-settings.md
@@ -1,27 +1,236 @@
 ---
 title: Custom Settings
-description: Customize chart appearance with AstroChart settings.
+description: Customize chart appearance and behavior with AstroChart settings.
 ---
 
 # Custom Settings
 
-AstroChart provides extensive customization options through the `Settings` object.
-
-## Basic Settings
+AstroChart provides extensive customization through a plain settings object passed as the fourth argument to `Chart`. Every key is optional — unspecified keys fall back to the library defaults.
 
 ```javascript
 import { Chart } from '@astrodraw/astrochart'
 
 const settings = {
-  BACKGROUND_COLOR: '#ffffff',
-  PAPER_BORDER_COLOR: '#000000'
+  COLOR_BACKGROUND: '#1a1a2e',
+  POINTS_COLOR: '#e0e0e0',
 }
 
-const chart = new Chart('chart', 600, 600, settings)
+const chart = new Chart('my-chart', 600, 600, settings)
+const radix = chart.radix(data)
+```
+
+---
+
+## Settings Reference by Category
+
+### Colors
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `COLOR_BACKGROUND` | `string` | `'#fff'` | SVG background fill color |
+| `POINTS_COLOR` | `string` | `'#000'` | Color of planet symbols |
+| `SIGNS_COLOR` | `string` | `'#000'` | Color of zodiac sign symbols |
+| `CIRCLE_COLOR` | `string` | `'#333'` | Color of chart ring circles |
+| `LINE_COLOR` | `string` | `'#333'` | Color of spoke/house lines |
+| `SYMBOL_AXIS_FONT_COLOR` | `string` | `'#333'` | Color of As/Ds/Mc/Ic labels |
+| `CUSPS_FONT_COLOR` | `string` | `'#000'` | Color of cusp number labels |
+| `COLOR_ARIES` | `string` | `'#FF4500'` | Sign sector color — Aries |
+| `COLOR_TAURUS` | `string` | `'#8B4513'` | Sign sector color — Taurus |
+| `COLOR_GEMINI` | `string` | `'#87CEEB'` | Sign sector color — Gemini |
+| `COLOR_CANCER` | `string` | `'#27AE60'` | Sign sector color — Cancer |
+| `COLOR_LEO` | `string` | `'#FF4500'` | Sign sector color — Leo |
+| `COLOR_VIRGO` | `string` | `'#8B4513'` | Sign sector color — Virgo |
+| `COLOR_LIBRA` | `string` | `'#87CEEB'` | Sign sector color — Libra |
+| `COLOR_SCORPIO` | `string` | `'#27AE60'` | Sign sector color — Scorpio |
+| `COLOR_SAGITTARIUS` | `string` | `'#FF4500'` | Sign sector color — Sagittarius |
+| `COLOR_CAPRICORN` | `string` | `'#8B4513'` | Sign sector color — Capricorn |
+| `COLOR_AQUARIUS` | `string` | `'#87CEEB'` | Sign sector color — Aquarius |
+| `COLOR_PISCES` | `string` | `'#27AE60'` | Sign sector color — Pisces |
+| `COLORS_SIGNS` | `string[]` | *(array of the 12 above)* | Ordered array of all 12 sign colors |
+
+### Symbols
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `SYMBOL_SCALE` | `number` | `1` | Global scale factor for all symbols |
+| `SYMBOL_SUN` | `string` | `'Sun'` | Key name for Sun symbol |
+| `SYMBOL_MOON` | `string` | `'Moon'` | Key name for Moon symbol |
+| `SYMBOL_MERCURY` | `string` | `'Mercury'` | Key name for Mercury symbol |
+| `SYMBOL_VENUS` | `string` | `'Venus'` | Key name for Venus symbol |
+| `SYMBOL_MARS` | `string` | `'Mars'` | Key name for Mars symbol |
+| `SYMBOL_JUPITER` | `string` | `'Jupiter'` | Key name for Jupiter symbol |
+| `SYMBOL_SATURN` | `string` | `'Saturn'` | Key name for Saturn symbol |
+| `SYMBOL_URANUS` | `string` | `'Uranus'` | Key name for Uranus symbol |
+| `SYMBOL_NEPTUNE` | `string` | `'Neptune'` | Key name for Neptune symbol |
+| `SYMBOL_PLUTO` | `string` | `'Pluto'` | Key name for Pluto symbol |
+| `SYMBOL_CHIRON` | `string` | `'Chiron'` | Key name for Chiron symbol |
+| `SYMBOL_LILITH` | `string` | `'Lilith'` | Key name for Lilith symbol |
+| `SYMBOL_NNODE` | `string` | `'NNode'` | Key name for North Node symbol |
+| `SYMBOL_SNODE` | `string` | `'SNode'` | Key name for South Node symbol |
+| `SYMBOL_FORTUNE` | `string` | `'Fortune'` | Key name for Part of Fortune symbol |
+| `SYMBOL_AS` | `string` | `'As'` | Ascendant axis label |
+| `SYMBOL_DS` | `string` | `'Ds'` | Descendant axis label |
+| `SYMBOL_MC` | `string` | `'Mc'` | Midheaven axis label |
+| `SYMBOL_IC` | `string` | `'Ic'` | Imum Coeli axis label |
+| `SYMBOL_SIGNS` | `string[]` | *(all 12 sign names)* | Ordered array of sign name keys |
+| `CUSTOM_SYMBOL_FN` | `function \| null` | `null` | Custom symbol renderer — see [Custom Symbols](./custom-symbols) |
+
+### Geometry
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `MARGIN` | `number` | `50` | Outer margin in px |
+| `PADDING` | `number` | `18` | Inner padding in px |
+| `SHIFT_IN_DEGREES` | `number` | `180` | Chart rotation offset (0° = West) |
+| `INDOOR_CIRCLE_RADIUS_RATIO` | `number` | `2` | Divisor for inner-most circle radius |
+| `INNER_CIRCLE_RADIUS_RATIO` | `number` | `8` | Divisor for planet ring inner edge |
+| `RULER_RADIUS` | `number` | `4` | Divisor for degree ruler band width |
+| `COLLISION_RADIUS` | `number` | `10` | Planet collision avoidance radius (px) at scale 1 |
+
+### Stroke & Lines
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `POINTS_STROKE` | `number` | `1.8` | Stroke width for planet symbols |
+| `SIGNS_STROKE` | `number` | `1.5` | Stroke width for sign symbols |
+| `CIRCLE_STRONG` | `number` | `2` | Stroke width for circles |
+| `SYMBOL_AXIS_STROKE` | `number` | `1.6` | Stroke width for axis labels |
+| `CUSPS_STROKE` | `number` | `1` | Stroke width for cusp lines |
+| `STROKE_ONLY` | `boolean` | `false` | Render all symbols as outlines only (no fill) |
+
+### Aspects
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `ASPECTS` | `Aspect` | *(see below)* | Aspect definitions — degree, orbit, and color |
+
+Default `ASPECTS` value:
+```javascript
+{
+  conjunction: { degree: 0,   orbit: 10, color: 'transparent' },
+  square:      { degree: 90,  orbit: 8,  color: '#FF4500' },
+  trine:       { degree: 120, orbit: 8,  color: '#27AE60' },
+  opposition:  { degree: 180, orbit: 10, color: '#27AE60' }
+}
+```
+
+### Dignities
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `SHOW_DIGNITIES_TEXT` | `boolean` | `true` | Show dignity labels next to planets |
+| `DIGNITIES_RULERSHIP` | `string` | `'r'` | Label for rulership dignity |
+| `DIGNITIES_DETRIMENT` | `string` | `'d'` | Label for detriment |
+| `DIGNITIES_EXALTATION` | `string` | `'e'` | Label for exaltation |
+| `DIGNITIES_EXACT_EXALTATION` | `string` | `'E'` | Label for exact exaltation |
+| `DIGNITIES_FALL` | `string` | `'f'` | Label for fall |
+| `DIGNITIES_EXACT_EXALTATION_DEFAULT` | `Dignity[]` | *(Crowley positions)* | Exact exaltation positions |
+
+### Animation
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `ANIMATION_CUSPS_ROTATION_SPEED` | `number` | `2` | Transit rotation animation speed (0–4) |
+
+### Interaction
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `ADD_CLICK_AREA` | `boolean` | `false` | Enable click-event areas on chart elements |
+
+### Debug
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `DEBUG` | `boolean` | `false` | Log internal debug information to the console |
+
+---
+
+## Practical Examples
+
+### Dark Theme
+
+```javascript
+import { Chart } from '@astrodraw/astrochart'
+
+const darkSettings = {
+  COLOR_BACKGROUND: '#1a1a2e',
+  POINTS_COLOR: '#e0e0ff',
+  SIGNS_COLOR: '#aaaacc',
+  CIRCLE_COLOR: '#444466',
+  LINE_COLOR: '#444466',
+  SYMBOL_AXIS_FONT_COLOR: '#aaaacc',
+  CUSPS_FONT_COLOR: '#aaaacc',
+  COLOR_ARIES: '#cc3300',
+  COLOR_TAURUS: '#664411',
+  COLOR_GEMINI: '#336699',
+  COLOR_CANCER: '#1e7a4a',
+  COLOR_LEO: '#cc3300',
+  COLOR_VIRGO: '#664411',
+  COLOR_LIBRA: '#336699',
+  COLOR_SCORPIO: '#1e7a4a',
+  COLOR_SAGITTARIUS: '#cc3300',
+  COLOR_CAPRICORN: '#664411',
+  COLOR_AQUARIUS: '#336699',
+  COLOR_PISCES: '#1e7a4a',
+  COLORS_SIGNS: ['#cc3300','#664411','#336699','#1e7a4a','#cc3300','#664411','#336699','#1e7a4a','#cc3300','#664411','#336699','#1e7a4a'],
+  ASPECTS: {
+    conjunction: { degree: 0,   orbit: 10, color: 'transparent' },
+    square:      { degree: 90,  orbit: 8,  color: '#ff6633' },
+    trine:       { degree: 120, orbit: 8,  color: '#33cc77' },
+    opposition:  { degree: 180, orbit: 10, color: '#6699ff' }
+  }
+}
+
+const chart = new Chart('chart', 600, 600, darkSettings)
 chart.radix(data)
 ```
 
+### Stroke-Only Mode
+
+Render all planet and sign symbols as outlines with no fill — useful for monochrome or print output:
+
+```javascript
+const chart = new Chart('chart', 600, 600, { STROKE_ONLY: true })
+chart.radix(data)
+```
+
+### Custom Aspect Colors
+
+Override just the aspect colors without touching any other settings:
+
+```javascript
+const chart = new Chart('chart', 600, 600, {
+  ASPECTS: {
+    conjunction: { degree: 0,   orbit: 10, color: '#9b59b6' },
+    square:      { degree: 90,  orbit: 8,  color: '#e74c3c' },
+    trine:       { degree: 120, orbit: 8,  color: '#2ecc71' },
+    opposition:  { degree: 180, orbit: 10, color: '#3498db' }
+  }
+})
+chart.radix(data)
+```
+
+### Scale Symbols Up
+
+Increase the size of all planet and sign symbols:
+
+```javascript
+const chart = new Chart('chart', 700, 700, { SYMBOL_SCALE: 1.4 })
+chart.radix(data)
+```
+
+### Hide Dignity Labels
+
+```javascript
+const chart = new Chart('chart', 600, 600, { SHOW_DIGNITIES_TEXT: false })
+chart.radix(data)
+```
+
+---
+
 ## Next Steps
 
-- **[Types Reference](../api/types)** — See all available settings
-- **[Custom Symbols](./custom-symbols)** — Create custom symbols
+- **[Custom Symbols](./custom-symbols)** — Replace individual planet symbols with your own SVG
+- **[Click Events](./click-events)** — Add interactivity to chart elements
+- **[Settings API Reference](../api/settings)** — Full settings type definitions

--- a/website/src/content/docs/guides/custom-symbols.md
+++ b/website/src/content/docs/guides/custom-symbols.md
@@ -1,24 +1,62 @@
 ---
 title: Custom Symbols
-description: Replace default symbols with your own designs.
+description: Replace default planet and sign symbols with your own SVG elements.
 ---
 
 # Custom Symbols
 
-AstroChart allows you to define custom SVG symbols for planets, signs, and other chart elements.
+AstroChart lets you replace any planet or sign symbol with a custom SVG element via the `CUSTOM_SYMBOL_FN` setting. This is useful for branding, accessibility, or artistic chart styles.
 
-## Custom Symbol Function
+---
+
+## The `CUSTOM_SYMBOL_FN` Setting
+
+Set `CUSTOM_SYMBOL_FN` to a function with the following signature:
+
+```typescript
+(name: string, x: number, y: number, context: SVG) => Element
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | `string` | The symbol name (e.g. `'Sun'`, `'Moon'`, `'Aries'`) |
+| `x` | `number` | The horizontal center coordinate on the SVG canvas |
+| `y` | `number` | The vertical center coordinate on the SVG canvas |
+| `context` | `SVG` | The internal SVG helper — use it to create elements in the correct namespace |
+
+The function **must** return a valid SVG `Element`. Returning `null` or `undefined` causes the library to fall back to the built-in symbol for that name.
+
+---
+
+## Example: Replace Sun With a Custom Circle
 
 ```javascript
+import { Chart } from '@astrodraw/astrochart'
+
 const settings = {
   CUSTOM_SYMBOL_FN: (name, x, y, context) => {
-    // Create your own SVG element
-    const symbol = document.createElementNS('http://www.w3.org/2000/svg', 'circle')
-    symbol.setAttribute('cx', x)
-    symbol.setAttribute('cy', y)
-    symbol.setAttribute('r', 8)
-    symbol.setAttribute('fill', '#ff0000')
-    return symbol
+    if (name !== 'Sun') return null // use defaults for everything else
+
+    // Create a styled circle as a custom Sun symbol
+    const g = document.createElementNS('http://www.w3.org/2000/svg', 'g')
+
+    const outer = document.createElementNS('http://www.w3.org/2000/svg', 'circle')
+    outer.setAttribute('cx', String(x))
+    outer.setAttribute('cy', String(y))
+    outer.setAttribute('r', '9')
+    outer.setAttribute('fill', '#FFD700')
+    outer.setAttribute('stroke', '#B8860B')
+    outer.setAttribute('stroke-width', '1.5')
+
+    const dot = document.createElementNS('http://www.w3.org/2000/svg', 'circle')
+    dot.setAttribute('cx', String(x))
+    dot.setAttribute('cy', String(y))
+    dot.setAttribute('r', '2.5')
+    dot.setAttribute('fill', '#B8860B')
+
+    g.appendChild(outer)
+    g.appendChild(dot)
+    return g
   }
 }
 
@@ -26,7 +64,78 @@ const chart = new Chart('chart', 600, 600, settings)
 chart.radix(data)
 ```
 
+---
+
+## Example: Selective Custom Symbols
+
+Return `null` for names you want to keep as defaults; return an element only for the symbols you want to customise:
+
+```javascript
+const CUSTOM_PLANETS = new Set(['Sun', 'Moon', 'Mars'])
+
+const settings = {
+  CUSTOM_SYMBOL_FN: (name, x, y, context) => {
+    if (!CUSTOM_PLANETS.has(name)) return null
+
+    const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle')
+    circle.setAttribute('cx', String(x))
+    circle.setAttribute('cy', String(y))
+    circle.setAttribute('r', '8')
+
+    const colors = { Sun: '#FFD700', Moon: '#C0C0C0', Mars: '#FF4500' }
+    circle.setAttribute('fill', colors[name] ?? '#888')
+    circle.setAttribute('stroke', '#fff')
+    circle.setAttribute('stroke-width', '1')
+
+    return circle
+  }
+}
+```
+
+---
+
+## Example: Text / Emoji Symbols
+
+You can even use SVG `<text>` elements to render emoji or Unicode glyphs as symbols:
+
+```javascript
+const EMOJI = {
+  Sun: '☀️',
+  Moon: '🌙',
+  Mars: '♂',
+  Venus: '♀',
+}
+
+const settings = {
+  CUSTOM_SYMBOL_FN: (name, x, y, context) => {
+    const glyph = EMOJI[name]
+    if (!glyph) return null
+
+    const text = document.createElementNS('http://www.w3.org/2000/svg', 'text')
+    text.setAttribute('x', String(x))
+    text.setAttribute('y', String(y))
+    text.setAttribute('text-anchor', 'middle')
+    text.setAttribute('dominant-baseline', 'central')
+    text.setAttribute('font-size', '14')
+    text.textContent = glyph
+    return text
+  }
+}
+```
+
+---
+
+## Important Notes
+
+- The function is called for **every** planet and sign symbol on the chart. Return `null` or `undefined` to use the built-in symbol for that name.
+- The returned element **must** be a valid SVG `Element` created with `document.createElementNS('http://www.w3.org/2000/svg', ...)`.
+- The `name` parameter matches the `SYMBOL_*` setting values (defaults: `'Sun'`, `'Moon'`, `'Aries'`, etc.).
+- Use `x` and `y` as the center of the symbol — do not offset them unless you intentionally want to shift placement.
+- The `context` parameter is the library's internal SVG helper; you may use it but `document.createElementNS` is sufficient for most cases.
+
+---
+
 ## Next Steps
 
-- **[Custom Settings](./custom-settings)** — Explore more settings
-- **[API Reference](../api/chart)** — See all methods
+- **[Custom Settings](./custom-settings)** — Explore all appearance settings
+- **[Settings API Reference](../api/settings)** — Full settings type documentation

--- a/website/src/content/docs/guides/frameworks/angular.md
+++ b/website/src/content/docs/guides/frameworks/angular.md
@@ -5,52 +5,161 @@ description: Integrate AstroChart with Angular applications.
 
 # Using AstroChart with Angular
 
-This guide shows how to use AstroChart in Angular applications.
+This guide covers integrating AstroChart into Angular components using `ngAfterViewInit`, `ngOnDestroy`, and `@ViewChild`.
+
+---
 
 ## Basic Component
 
+Use `@ViewChild` to get a reference to the container element, then initialise the chart in `ngAfterViewInit`:
+
 ```typescript
-import { Component, ViewChild, ElementRef, AfterViewInit, Input } from '@angular/core'
+import {
+  Component,
+  ViewChild,
+  ElementRef,
+  AfterViewInit,
+  OnDestroy,
+  Input,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core'
 import { Chart } from '@astrodraw/astrochart'
 
 @Component({
   selector: 'app-astrochart',
-  template: '<div #container></div>',
-  styleUrls: ['./astrochart.component.css']
+  template: `<div #chartContainer [id]="containerId"></div>`,
+  styleUrls: ['./astrochart.component.scss'],
 })
-export class AstroChartComponent implements AfterViewInit {
-  @ViewChild('container') container!: ElementRef
+export class AstroChartComponent implements AfterViewInit, OnDestroy {
+  @ViewChild('chartContainer') containerRef!: ElementRef<HTMLDivElement>
+
   @Input() data: any
   @Input() width = 600
   @Input() height = 600
+  @Input() settings: Record<string, any> = {}
 
-  ngAfterViewInit() {
-    if (!this.container) return
-    const chart = new Chart(this.container.nativeElement.id, this.width, this.height)
+  containerId = `astrochart-${Math.random().toString(36).slice(2, 9)}`
+
+  ngAfterViewInit(): void {
+    this.renderChart()
+  }
+
+  ngOnDestroy(): void {
+    if (this.containerRef?.nativeElement) {
+      this.containerRef.nativeElement.innerHTML = ''
+    }
+  }
+
+  private renderChart(): void {
+    const el = this.containerRef?.nativeElement
+    if (!el) return
+
+    el.innerHTML = '' // clear any previous render
+    const chart = new Chart(this.containerId, this.width, this.height, this.settings)
     chart.radix(this.data)
   }
 }
 ```
 
-## With Universal (SSR)
+Usage in a parent template:
 
-Guard against server-side rendering:
+```html
+<app-astrochart [data]="natalData" [width]="600" [height]="600" />
+```
+
+---
+
+## Re-rendering on Input Changes
+
+Implement `OnChanges` to re-render when `data` or `settings` are updated:
 
 ```typescript
-import { isPlatformBrowser } from '@angular/common'
-import { Component, Inject, PLATFORM_ID } from '@angular/core'
-
-export class AstroChartComponent {
-  constructor(@Inject(PLATFORM_ID) private platformId: Object) {}
-
-  ngAfterViewInit() {
-    if (!isPlatformBrowser(this.platformId)) return
-    // Initialize chart
+ngOnChanges(changes: SimpleChanges): void {
+  if ((changes['data'] || changes['settings']) && this.containerRef) {
+    this.renderChart()
   }
 }
 ```
+
+Add `OnChanges` to the `implements` clause:
+
+```typescript
+export class AstroChartComponent implements AfterViewInit, OnDestroy, OnChanges {
+```
+
+---
+
+## Server-Side Rendering (Angular Universal)
+
+AstroChart requires a DOM and must only run in the browser. Guard with `isPlatformBrowser`:
+
+```typescript
+import { isPlatformBrowser } from '@angular/common'
+import { Inject, PLATFORM_ID } from '@angular/core'
+
+export class AstroChartComponent implements AfterViewInit, OnDestroy {
+  constructor(@Inject(PLATFORM_ID) private platformId: object) {}
+
+  ngAfterViewInit(): void {
+    if (!isPlatformBrowser(this.platformId)) return
+    this.renderChart()
+  }
+}
+```
+
+---
+
+## Running Outside the Angular Zone (Performance Tip)
+
+Chart rendering involves no Angular data-binding, so you can run it outside the Angular change-detection zone to avoid unnecessary checks:
+
+```typescript
+import { NgZone } from '@angular/core'
+
+export class AstroChartComponent implements AfterViewInit, OnDestroy {
+  constructor(private ngZone: NgZone) {}
+
+  ngAfterViewInit(): void {
+    this.ngZone.runOutsideAngular(() => {
+      this.renderChart()
+    })
+  }
+}
+```
+
+This is optional but can improve performance when `data` changes frequently.
+
+---
+
+## Standalone Component (Angular 15+)
+
+If you use standalone components, import `CommonModule` or `NgIf` as needed and set `standalone: true`:
+
+```typescript
+@Component({
+  selector: 'app-astrochart',
+  standalone: true,
+  imports: [],
+  template: `<div #chartContainer [id]="containerId"></div>`,
+})
+export class AstroChartComponent implements AfterViewInit, OnDestroy {
+  // ... same implementation
+}
+```
+
+---
+
+## Notes
+
+- **Always clean up** in `ngOnDestroy` by clearing `innerHTML`. This prevents SVG content from leaking when the component is removed.
+- **Unique container IDs:** Generate a unique `id` per instance (as shown with `Math.random()` above) if multiple chart components can appear on the same page simultaneously.
+- **No Zone.js dependency:** AstroChart does not use signals, observables, or Zone.js — it is a plain DOM/SVG library that is safe to run outside Angular's zone.
+
+---
 
 ## Next Steps
 
 - **[React Integration](./react)** — Use with React
 - **[Vue Integration](./vue)** — Use with Vue
+- **[Multiple Charts](../multiple-charts)** — Render several instances on one page

--- a/website/src/content/docs/guides/frameworks/angular.md
+++ b/website/src/content/docs/guides/frameworks/angular.md
@@ -21,8 +21,6 @@ import {
   AfterViewInit,
   OnDestroy,
   Input,
-  OnChanges,
-  SimpleChanges,
 } from '@angular/core'
 import { Chart } from '@astrodraw/astrochart'
 

--- a/website/src/content/docs/guides/frameworks/vue.md
+++ b/website/src/content/docs/guides/frameworks/vue.md
@@ -1,57 +1,197 @@
 ---
 title: Vue
-description: Integrate AstroChart with Vue applications.
+description: Integrate AstroChart with Vue 3 and Vue 2 applications.
 ---
 
 # Using AstroChart with Vue
 
-This guide shows how to use AstroChart in Vue applications.
+This guide shows how to integrate AstroChart into Vue applications, covering Vue 3 Composition API, Vue 2 Options API, and re-rendering on data changes.
 
-## Basic Component
+---
+
+## Vue 3 — Composition API
+
+Use a template ref and `onMounted`/`onUnmounted` to manage the chart lifecycle:
 
 ```vue
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onUnmounted, watch } from 'vue'
 import { Chart } from '@astrodraw/astrochart'
+import type { AstroData } from '@astrodraw/astrochart'
 
-const container = ref<HTMLDivElement | null>(null)
+interface Props {
+  data: AstroData
+  width?: number
+  height?: number
+}
 
-const props = defineProps({
-  data: Object,
-  width: { type: Number, default: 600 },
-  height: { type: Number, default: 600 }
+const props = withDefaults(defineProps<Props>(), {
+  width: 600,
+  height: 600,
 })
 
-onMounted(() => {
-  if (!container.value) return
-  const chart = new Chart(container.value.id, props.width, props.height)
+const containerRef = ref<HTMLDivElement | null>(null)
+
+function renderChart() {
+  if (!containerRef.value) return
+
+  // Clear any previous chart before re-rendering
+  containerRef.value.innerHTML = ''
+
+  const chart = new Chart(containerRef.value.id, props.width, props.height)
   chart.radix(props.data)
+}
+
+onMounted(() => {
+  renderChart()
+})
+
+// Re-render whenever the data prop changes
+watch(() => props.data, () => {
+  renderChart()
+}, { deep: true })
+
+onUnmounted(() => {
+  // Clean up SVG content when the component is destroyed
+  if (containerRef.value) {
+    containerRef.value.innerHTML = ''
+  }
 })
 </script>
 
 <template>
-  <div id="astrochart-root" ref="container" />
+  <div id="astrochart-root" ref="containerRef" />
 </template>
 ```
 
-## With Nuxt
+> **Note:** AstroChart is not reactive by default. To update the chart when your data changes, clear `innerHTML` and call `chart.radix()` again — as shown in the `watch` callback above.
 
-For Nuxt (SSR):
+---
+
+## Vue 3 — with Settings Prop
+
+Pass custom settings as a prop for per-instance configuration:
+
+```vue
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { Chart } from '@astrodraw/astrochart'
+
+const props = defineProps({
+  data: { type: Object, required: true },
+  settings: { type: Object, default: () => ({}) },
+  width: { type: Number, default: 600 },
+  height: { type: Number, default: 600 },
+})
+
+const containerRef = ref<HTMLDivElement | null>(null)
+
+onMounted(() => {
+  if (!containerRef.value) return
+  const chart = new Chart(containerRef.value.id, props.width, props.height, props.settings)
+  chart.radix(props.data)
+})
+
+onUnmounted(() => {
+  if (containerRef.value) containerRef.value.innerHTML = ''
+})
+</script>
+
+<template>
+  <div id="astrochart-instance" ref="containerRef" />
+</template>
+```
+
+Usage:
+
+```vue
+<AstroChartComponent
+  :data="chartData"
+  :settings="{ COLOR_BACKGROUND: '#1a1a2e', POINTS_COLOR: '#e0e0ff' }"
+  :width="700"
+  :height="700"
+/>
+```
+
+---
+
+## Vue 2 — Options API
+
+For Vue 2, use `mounted` and `beforeDestroy`:
+
+```vue
+<template>
+  <div id="astrochart-root" ref="container" />
+</template>
+
+<script>
+import { Chart } from '@astrodraw/astrochart'
+
+export default {
+  name: 'AstroChartComponent',
+  props: {
+    data: { type: Object, required: true },
+    width: { type: Number, default: 600 },
+    height: { type: Number, default: 600 },
+  },
+  mounted() {
+    const el = this.$refs.container
+    if (!el) return
+    const chart = new Chart(el.id, this.width, this.height)
+    chart.radix(this.data)
+    this._chart = chart
+  },
+  beforeDestroy() {
+    const el = this.$refs.container
+    if (el) el.innerHTML = ''
+  },
+  watch: {
+    data: {
+      handler() {
+        const el = this.$refs.container
+        if (!el) return
+        el.innerHTML = ''
+        const chart = new Chart(el.id, this.width, this.height)
+        chart.radix(this.data)
+      },
+      deep: true,
+    },
+  },
+}
+</script>
+```
+
+---
+
+## Using with Nuxt (SSR)
+
+AstroChart manipulates the DOM and must only run in the browser. Wrap your component in `<ClientOnly>`:
 
 ```vue
 <template>
   <ClientOnly>
-    <AstroChart :data="chartData" />
+    <AstroChartComponent :data="chartData" />
   </ClientOnly>
 </template>
 
 <script setup>
-import AstroChart from '~/components/AstroChart.vue'
-const chartData = ref({})
+import AstroChartComponent from '~/components/AstroChartComponent.vue'
+const chartData = { planets: { Sun: [120.5] }, cusps: [0,30,60,90,120,150,180,210,240,270,300,330] }
 </script>
 ```
+
+---
+
+## Important Notes
+
+- **AstroChart is not reactive.** It renders to SVG once and does not observe data changes. Use a `watch` + `innerHTML = ''` pattern to re-render on changes.
+- **Always clean up** in `onUnmounted` / `beforeDestroy` to avoid orphaned SVG content when the component is removed from the DOM.
+- **Unique element IDs:** If you render multiple chart components, ensure each container has a unique `id` attribute — otherwise charts will overwrite each other.
+
+---
 
 ## Next Steps
 
 - **[React Integration](./react)** — Use with React
 - **[Angular Integration](./angular)** — Use with Angular
+- **[Multiple Charts](../multiple-charts)** — Render several instances on one page

--- a/website/src/content/docs/guides/frameworks/vue.md
+++ b/website/src/content/docs/guides/frameworks/vue.md
@@ -17,7 +17,8 @@ Use a template ref and `onMounted`/`onUnmounted` to manage the chart lifecycle:
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, watch } from 'vue'
 import { Chart } from '@astrodraw/astrochart'
-import type { AstroData } from '@astrodraw/astrochart'
+
+type AstroData = Parameters<InstanceType<typeof Chart>['radix']>[0]
 
 interface Props {
   data: AstroData

--- a/website/src/content/docs/guides/frameworks/vue.md
+++ b/website/src/content/docs/guides/frameworks/vue.md
@@ -20,6 +20,8 @@ import { Chart } from '@astrodraw/astrochart'
 
 type AstroData = Parameters<InstanceType<typeof Chart>['radix']>[0]
 
+const chartId = `astrochart-${Math.random().toString(36).slice(2, 9)}`
+
 interface Props {
   data: AstroData
   width?: number
@@ -61,7 +63,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div id="astrochart-root" ref="containerRef" />
+  <div :id="chartId" ref="containerRef" />
 </template>
 ```
 
@@ -86,6 +88,7 @@ const props = defineProps({
 })
 
 const containerRef = ref<HTMLDivElement | null>(null)
+const chartId = `astrochart-${Math.random().toString(36).slice(2, 9)}`
 
 onMounted(() => {
   if (!containerRef.value) return
@@ -99,7 +102,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div id="astrochart-instance" ref="containerRef" />
+  <div :id="chartId" ref="containerRef" />
 </template>
 ```
 
@@ -122,7 +125,7 @@ For Vue 2, use `mounted` and `beforeDestroy`:
 
 ```vue
 <template>
-  <div id="astrochart-root" ref="container" />
+  <div :id="chartId" ref="container" />
 </template>
 
 <script>
@@ -134,6 +137,11 @@ export default {
     data: { type: Object, required: true },
     width: { type: Number, default: 600 },
     height: { type: Number, default: 600 },
+  },
+  data() {
+    return {
+      chartId: `astrochart-${Math.random().toString(36).slice(2, 9)}`,
+    }
   },
   mounted() {
     const el = this.$refs.container

--- a/website/src/content/docs/guides/multiple-charts.md
+++ b/website/src/content/docs/guides/multiple-charts.md
@@ -1,34 +1,138 @@
 ---
 title: Multiple Charts
-description: Render multiple independent charts on one page.
+description: Render multiple independent AstroChart instances on one page.
 ---
 
 # Multiple Charts
 
-You can render multiple independent charts on the same page by using unique container IDs.
+You can render as many chart instances as you need on a single page. Each instance is fully independent — they share no internal state. The only requirement is that **each chart must target a unique HTML element ID**.
 
-## Example
+---
+
+## Basic Example: Two Radix Charts
+
+```html
+<div id="chart-natal"></div>
+<div id="chart-solar"></div>
+```
 
 ```javascript
 import { Chart } from '@astrodraw/astrochart'
 
-// First chart
-const chart1 = new Chart('chart1', 400, 400)
-chart1.radix(data1)
+const natalData = {
+  planets: { Sun: [120.5], Moon: [45.2], Mercury: [110.3] },
+  cusps: [0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330]
+}
 
-// Second chart
-const chart2 = new Chart('chart2', 400, 400)
-chart2.radix(data2)
+const solarData = {
+  planets: { Sun: [200.0], Moon: [88.4], Mars: [15.7] },
+  cusps: [15, 45, 75, 105, 135, 165, 195, 225, 255, 285, 315, 345]
+}
+
+const natal = new Chart('chart-natal', 500, 500)
+natal.radix(natalData)
+
+const solar = new Chart('chart-solar', 500, 500)
+solar.radix(solarData)
+```
+
+---
+
+## Radix + Transit on the Same Page
+
+A common use case is displaying a natal chart alongside a transit chart. Each `Chart` instance is independent:
+
+```html
+<div id="natal-chart"></div>
+<div id="transit-chart"></div>
+```
+
+```javascript
+import { Chart } from '@astrodraw/astrochart'
+
+// Natal chart
+const natalChart = new Chart('natal-chart', 600, 600)
+const radix = natalChart.radix(natalData)
+
+// Transit chart — shows natal as inner wheel, transit as outer wheel
+const transitChart = new Chart('transit-chart', 600, 600)
+const transitRadix = transitChart.radix(natalData)
+transitRadix.transit(transitData)
+```
+
+---
+
+## Different Settings Per Instance
+
+Each `Chart` constructor accepts its own settings object, so you can style each chart differently:
+
+```javascript
+const darkSettings = {
+  COLOR_BACKGROUND: '#1a1a2e',
+  POINTS_COLOR: '#e0e0ff',
+  CIRCLE_COLOR: '#444466',
+  LINE_COLOR: '#444466',
+}
+
+const lightSettings = {
+  COLOR_BACKGROUND: '#ffffff',
+  POINTS_COLOR: '#222222',
+  STROKE_ONLY: true,
+}
+
+const chart1 = new Chart('chart-dark', 600, 600, darkSettings)
+chart1.radix(natalData)
+
+const chart2 = new Chart('chart-light', 600, 600, lightSettings)
+chart2.radix(solarData)
+```
+
+---
+
+## Dynamically Creating Charts in a List
+
+You can generate chart containers programmatically and render into them:
+
+```javascript
+import { Chart } from '@astrodraw/astrochart'
+
+const charts = [
+  { id: 'chart-0', data: data1 },
+  { id: 'chart-1', data: data2 },
+  { id: 'chart-2', data: data3 },
+]
+
+const container = document.getElementById('chart-list')
+
+charts.forEach (({ id, data }) => {
+  const el = document.createElement('div')
+  el.id = id
+  container.appendChild(el)
+
+  const chart = new Chart(id, 400, 400)
+  chart.radix(data)
+})
 ```
 
 HTML:
 
 ```html
-<div id="chart1"></div>
-<div id="chart2"></div>
+<div id="chart-list"></div>
 ```
+
+---
+
+## Notes
+
+- **Each chart requires a unique element ID.** Reusing the same ID will cause charts to overwrite each other.
+- Charts are fully independent — changing data in one chart has no effect on any other.
+- There is no global chart registry; hold references to each `Chart` instance yourself if you need to update or destroy them later.
+- To replace a chart's contents, clear the container element (`el.innerHTML = ''`) and create a new `Chart` instance.
+
+---
 
 ## Next Steps
 
-- **[Click Events](./click-events)** — Add interactivity
-- **[Framework Integrations](./frameworks/react)** — Use with React, Vue, etc.
+- **[Custom Settings](./custom-settings)** — Style each chart instance independently
+- **[Click Events](./click-events)** — Add per-chart click handlers
+- **[Framework Integrations](./frameworks/react)** — Manage multiple charts in React, Vue, or Angular

--- a/website/src/data/demoData.ts
+++ b/website/src/data/demoData.ts
@@ -94,3 +94,41 @@ export const animationData = {
   radix: defaultRadixData,
   transit: defaultTransitData
 }
+
+/**
+ * Target transit data for animation demo.
+ * Planets are shifted ~30–90° from defaultTransitData so the animation is visible.
+ */
+export const animateTargetData: AstroData = {
+  planets: {
+    Sun: [55.34, 0],        // moved ~30°
+    Moon: [242.45, 0],      // Moon moves fast
+    Mercury: [82.67, 0],
+    Venus: [98.12, 0],
+    Mars: [228.34, 0],
+    Jupiter: [358.56, 0],
+    Saturn: [318.78, 0],
+    Uranus: [328.90, 0],
+    Neptune: [355.12, 0],
+    Pluto: [330.34, 0],
+    Chiron: [198.67, 0],
+    NNode: [92.45, 0],
+    SNode: [272.45, 0],
+    Lilith: [245.23, 0],
+    Fortune: [75.67, 0]
+  },
+  cusps: [
+    345.45,
+    65.67,
+    95.23,
+    122.45,
+    155.67,
+    185.89,
+    165.45,
+    245.67,
+    275.23,
+    302.45,
+    335.67,
+    5.89
+  ]
+}

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -1,10 +1,19 @@
 /* AstroChart Custom Styles */
 
+/* Light mode — indigo accent palette */
 :root {
-  /* Override Starlight theme colors if needed */
-  --sl-color-accent-low: hsl(var(--sl-hue), 100%, 97%);
-  --sl-color-accent: hsl(var(--sl-hue), 100%, 50%);
-  --sl-color-accent-high: hsl(var(--sl-hue), 100%, 20%);
+  --sl-color-accent-low: hsl(240, 60%, 95%);
+  --sl-color-accent: hsl(240, 60%, 50%);
+  --sl-color-accent-high: hsl(240, 60%, 20%);
+}
+
+/* Dark mode — richer indigo with higher contrast */
+:root[data-theme="dark"] {
+  --sl-color-accent-low: hsl(240, 40%, 20%);
+  --sl-color-accent: hsl(240, 70%, 65%);
+  --sl-color-accent-high: hsl(240, 70%, 90%);
+  /* Subtle radial gradient atmosphere via background-color override */
+  --sl-color-bg: hsl(240, 15%, 10%);
 }
 
 /* Chart demo containers */
@@ -12,6 +21,17 @@
   display: flex;
   justify-content: center;
   margin: 2rem 0;
+  background: #ffffff;
+  border: 1px solid hsl(240, 20%, 88%);
+  border-radius: 0.75rem;
+  box-shadow: 0 2px 12px 0 hsl(240, 30%, 80%, 0.35);
+  padding: 1.5rem;
+}
+
+:root[data-theme="dark"] .chart-demo {
+  background: hsl(240, 15%, 14%);
+  border-color: hsl(240, 20%, 25%);
+  box-shadow: 0 2px 16px 0 hsl(240, 40%, 5%, 0.6);
 }
 
 .chart-demo svg {

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -17,7 +17,7 @@
 }
 
 /* Chart demo containers */
-.chart-demo {
+.chart-demo-wrapper {
   display: flex;
   justify-content: center;
   margin: 2rem 0;
@@ -28,13 +28,13 @@
   padding: 1.5rem;
 }
 
-:root[data-theme="dark"] .chart-demo {
+:root[data-theme="dark"] .chart-demo-wrapper {
   background: hsl(240, 15%, 14%);
   border-color: hsl(240, 20%, 25%);
   box-shadow: 0 2px 16px 0 hsl(240, 40%, 5%, 0.6);
 }
 
-.chart-demo svg {
+.chart-demo-wrapper svg {
   max-width: 100%;
   height: auto;
 }


### PR DESCRIPTION
## Summary

- **#99 Theme & Logo** — Replace placeholder logo with a proper astrological wheel SVG (12 division marks, dual rings, crosshair axes, `currentColor` for light/dark); apply indigo accent palette to `custom.css` with full light/dark mode variants; wire `customCss` into `astro.config.mjs`
- **#100 Remaining Docs** — Enrich 9 stub pages with full, accurate content sourced directly from `settings.ts`: `custom-settings`, `custom-symbols`, `click-events`, `multiple-charts`, `api/settings` (all ~100 settings), `frameworks/vue`, `frameworks/angular`, `changelog`, `contributing`
- **#98 Gallery & Advanced Demos** — Add `aspects` mode to `ChartDemo`, create `gallery.mdx` with 4 live demos, add **Examples** sidebar group in `astro.config.mjs`
- **Fix** — Animation demo was crashing with `"Data is not set"` (`transit.animate()` requires a target data object); add `animateTargetData` and wire it with a forward/back toggle
- **Fix** — Gallery/guide code snippets were hard to read; replace light `#f5f5f5` pre background with dark `#1e1e2e` and explicit `#cdd6f4` text color

## Test plan

- [ ] `cd website && npm run dev` — dev server starts with no errors
- [ ] Homepage loads, radix and transit demos render
- [ ] Animation guide — "Start Animation" button animates planets, button toggles back on second click, no console errors
- [ ] Gallery page (`/gallery`) shows 4 live demos: radix, transit, aspects, animate
- [ ] Code snippets in Gallery/guides are dark-background with readable light text
- [ ] Sidebar shows: Getting Started → Guides → **Examples** → API Reference → Project
- [ ] Logo displays as an astrological wheel in header (adapts to light/dark)
- [ ] Accent color is indigo across the site in both light and dark modes
- [ ] All enriched doc pages render (custom-settings, click-events, frameworks/vue, frameworks/angular, changelog, contributing)
- [ ] `npm run build` from website/ completes with no errors

🤖 Generated with [eca](https://eca.dev)