### PR TITLE
docs: explain planetary dignity indicators

### DIFF
--- a/dist/jest.config.d.ts
+++ b/dist/jest.config.d.ts
@@ -1,0 +1,2 @@
+declare const _exports: import('ts-jest/dist/types').InitialOptionsTsJest;
+export = _exports;

--- a/dist/webpack.config.d.ts
+++ b/dist/webpack.config.d.ts
@@ -1,0 +1,21 @@
+export const entry: string;
+export namespace module {
+    const rules: {
+        test: RegExp;
+        use: string;
+        exclude: RegExp[];
+    }[];
+}
+export namespace resolve {
+    const extensions: string[];
+}
+export const mode: string;
+export namespace output {
+    const clean: boolean;
+    const path: string;
+    const filename: string;
+    namespace library {
+        const name: string;
+        const type: string;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@astrodraw/astrochart",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@astrodraw/astrochart",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.4.1",

--- a/website/src/content/docs/api/settings.md
+++ b/website/src/content/docs/api/settings.md
@@ -9,96 +9,98 @@ All settings are passed as a plain object to the `Chart` constructor. Every key 
 
 ```typescript
 import { Chart } from '@astrodraw/astrochart'
-const chart = new Chart('chart', 600, 600, { /* settings here */ })
+const chart = new Chart('chart', 600, 600, {
+  /* settings here */
+})
 ```
 
 ---
 
 ## General
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `SYMBOL_SCALE` | `number` | `1` | Global scale multiplier for all rendered symbols |
-| `COLOR_BACKGROUND` | `string` | `'#fff'` | SVG canvas background fill color |
-| `MARGIN` | `number` | `50` | Outer margin in pixels |
-| `PADDING` | `number` | `18` | Inner padding in pixels |
-| `SHIFT_IN_DEGREES` | `number` | `180` | Chart rotation offset; `180` places 0° on the left (West) |
-| `STROKE_ONLY` | `boolean` | `false` | Render all symbols as outlines — no fill |
-| `ADD_CLICK_AREA` | `boolean` | `false` | Add invisible click-target areas; required for click events |
-| `COLLISION_RADIUS` | `number` | `10` | Planet collision-avoidance radius in px (at `SYMBOL_SCALE: 1`) |
-| `DEBUG` | `boolean` | `false` | Print internal debug information to the browser console |
+| Setting            | Type      | Default  | Description                                                    |
+| ------------------ | --------- | -------- | -------------------------------------------------------------- |
+| `SYMBOL_SCALE`     | `number`  | `1`      | Global scale multiplier for all rendered symbols               |
+| `COLOR_BACKGROUND` | `string`  | `'#fff'` | SVG canvas background fill color                               |
+| `MARGIN`           | `number`  | `50`     | Outer margin in pixels                                         |
+| `PADDING`          | `number`  | `18`     | Inner padding in pixels                                        |
+| `SHIFT_IN_DEGREES` | `number`  | `180`    | Chart rotation offset; `180` places 0° on the left (West)      |
+| `STROKE_ONLY`      | `boolean` | `false`  | Render all symbols as outlines — no fill                       |
+| `ADD_CLICK_AREA`   | `boolean` | `false`  | Add invisible click-target areas; required for click events    |
+| `COLLISION_RADIUS` | `number`  | `10`     | Planet collision-avoidance radius in px (at `SYMBOL_SCALE: 1`) |
+| `DEBUG`            | `boolean` | `false`  | Print internal debug information to the browser console        |
 
 ---
 
 ## Points / Planets
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `POINTS_COLOR` | `string` | `'#000'` | Fill/stroke color for planet symbols |
-| `POINTS_TEXT_SIZE` | `number` | `8` | Font size in px for the text next to each planet (angle, retrograde, dignity) |
-| `POINTS_STROKE` | `number` | `1.8` | Stroke width for planet symbols |
+| Setting            | Type     | Default  | Description                                                                   |
+| ------------------ | -------- | -------- | ----------------------------------------------------------------------------- |
+| `POINTS_COLOR`     | `string` | `'#000'` | Fill/stroke color for planet symbols                                          |
+| `POINTS_TEXT_SIZE` | `number` | `8`      | Font size in px for the text next to each planet (angle, retrograde, dignity) |
+| `POINTS_STROKE`    | `number` | `1.8`    | Stroke width for planet symbols                                               |
 
 ---
 
 ## Signs
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `SIGNS_COLOR` | `string` | `'#000'` | Color for zodiac sign symbols |
-| `SIGNS_STROKE` | `number` | `1.5` | Stroke width for zodiac sign symbols |
-| `COLOR_ARIES` | `string` | `'#FF4500'` | Sector color — Aries |
-| `COLOR_TAURUS` | `string` | `'#8B4513'` | Sector color — Taurus |
-| `COLOR_GEMINI` | `string` | `'#87CEEB'` | Sector color — Gemini |
-| `COLOR_CANCER` | `string` | `'#27AE60'` | Sector color — Cancer |
-| `COLOR_LEO` | `string` | `'#FF4500'` | Sector color — Leo |
-| `COLOR_VIRGO` | `string` | `'#8B4513'` | Sector color — Virgo |
-| `COLOR_LIBRA` | `string` | `'#87CEEB'` | Sector color — Libra |
-| `COLOR_SCORPIO` | `string` | `'#27AE60'` | Sector color — Scorpio |
-| `COLOR_SAGITTARIUS` | `string` | `'#FF4500'` | Sector color — Sagittarius |
-| `COLOR_CAPRICORN` | `string` | `'#8B4513'` | Sector color — Capricorn |
-| `COLOR_AQUARIUS` | `string` | `'#87CEEB'` | Sector color — Aquarius |
-| `COLOR_PISCES` | `string` | `'#27AE60'` | Sector color — Pisces |
-| `COLORS_SIGNS` | `string[]` | *(array of the 12 above in order)* | Ordered array of all 12 sign sector colors |
+| Setting             | Type       | Default                            | Description                                |
+| ------------------- | ---------- | ---------------------------------- | ------------------------------------------ |
+| `SIGNS_COLOR`       | `string`   | `'#000'`                           | Color for zodiac sign symbols              |
+| `SIGNS_STROKE`      | `number`   | `1.5`                              | Stroke width for zodiac sign symbols       |
+| `COLOR_ARIES`       | `string`   | `'#FF4500'`                        | Sector color — Aries                       |
+| `COLOR_TAURUS`      | `string`   | `'#8B4513'`                        | Sector color — Taurus                      |
+| `COLOR_GEMINI`      | `string`   | `'#87CEEB'`                        | Sector color — Gemini                      |
+| `COLOR_CANCER`      | `string`   | `'#27AE60'`                        | Sector color — Cancer                      |
+| `COLOR_LEO`         | `string`   | `'#FF4500'`                        | Sector color — Leo                         |
+| `COLOR_VIRGO`       | `string`   | `'#8B4513'`                        | Sector color — Virgo                       |
+| `COLOR_LIBRA`       | `string`   | `'#87CEEB'`                        | Sector color — Libra                       |
+| `COLOR_SCORPIO`     | `string`   | `'#27AE60'`                        | Sector color — Scorpio                     |
+| `COLOR_SAGITTARIUS` | `string`   | `'#FF4500'`                        | Sector color — Sagittarius                 |
+| `COLOR_CAPRICORN`   | `string`   | `'#8B4513'`                        | Sector color — Capricorn                   |
+| `COLOR_AQUARIUS`    | `string`   | `'#87CEEB'`                        | Sector color — Aquarius                    |
+| `COLOR_PISCES`      | `string`   | `'#27AE60'`                        | Sector color — Pisces                      |
+| `COLORS_SIGNS`      | `string[]` | _(array of the 12 above in order)_ | Ordered array of all 12 sign sector colors |
 
 ---
 
 ## Circles & Lines
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `CIRCLE_COLOR` | `string` | `'#333'` | Color of chart ring circles |
-| `CIRCLE_STRONG` | `number` | `2` | Stroke width for circles |
-| `LINE_COLOR` | `string` | `'#333'` | Color of house spoke lines |
-| `INDOOR_CIRCLE_RADIUS_RATIO` | `number` | `2` | `radius / INDOOR_CIRCLE_RADIUS_RATIO` determines the inner-most circle size |
-| `INNER_CIRCLE_RADIUS_RATIO` | `number` | `8` | `radius - radius/INNER_CIRCLE_RADIUS_RATIO` determines the planet ring inner edge |
-| `RULER_RADIUS` | `number` | `4` | `(radius / INNER_CIRCLE_RADIUS_RATIO) / RULER_RADIUS` determines degree ruler band width |
+| Setting                      | Type     | Default  | Description                                                                              |
+| ---------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------- |
+| `CIRCLE_COLOR`               | `string` | `'#333'` | Color of chart ring circles                                                              |
+| `CIRCLE_STRONG`              | `number` | `2`      | Stroke width for circles                                                                 |
+| `LINE_COLOR`                 | `string` | `'#333'` | Color of house spoke lines                                                               |
+| `INDOOR_CIRCLE_RADIUS_RATIO` | `number` | `2`      | `radius / INDOOR_CIRCLE_RADIUS_RATIO` determines the inner-most circle size              |
+| `INNER_CIRCLE_RADIUS_RATIO`  | `number` | `8`      | `radius - radius/INNER_CIRCLE_RADIUS_RATIO` determines the planet ring inner edge        |
+| `RULER_RADIUS`               | `number` | `4`      | `(radius / INNER_CIRCLE_RADIUS_RATIO) / RULER_RADIUS` determines degree ruler band width |
 
 ---
 
 ## Axis & Cusps
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `SYMBOL_AS` | `string` | `'As'` | Ascendant axis label text |
-| `SYMBOL_DS` | `string` | `'Ds'` | Descendant axis label text |
-| `SYMBOL_MC` | `string` | `'Mc'` | Midheaven axis label text |
-| `SYMBOL_IC` | `string` | `'Ic'` | Imum Coeli axis label text |
-| `SYMBOL_AXIS_FONT_COLOR` | `string` | `'#333'` | Color for As/Ds/Mc/Ic labels |
-| `SYMBOL_AXIS_STROKE` | `number` | `1.6` | Stroke width for axis labels |
-| `CUSPS_STROKE` | `number` | `1` | Stroke width for cusp dividing lines |
-| `CUSPS_FONT_COLOR` | `string` | `'#000'` | Color of cusp number labels |
-| `SYMBOL_CUSP_1` | `string` | `'1'` | Label for cusp 1 |
-| `SYMBOL_CUSP_2` | `string` | `'2'` | Label for cusp 2 |
-| `SYMBOL_CUSP_3` | `string` | `'3'` | Label for cusp 3 |
-| `SYMBOL_CUSP_4` | `string` | `'4'` | Label for cusp 4 |
-| `SYMBOL_CUSP_5` | `string` | `'5'` | Label for cusp 5 |
-| `SYMBOL_CUSP_6` | `string` | `'6'` | Label for cusp 6 |
-| `SYMBOL_CUSP_7` | `string` | `'7'` | Label for cusp 7 |
-| `SYMBOL_CUSP_8` | `string` | `'8'` | Label for cusp 8 |
-| `SYMBOL_CUSP_9` | `string` | `'9'` | Label for cusp 9 |
-| `SYMBOL_CUSP_10` | `string` | `'10'` | Label for cusp 10 |
-| `SYMBOL_CUSP_11` | `string` | `'11'` | Label for cusp 11 |
-| `SYMBOL_CUSP_12` | `string` | `'12'` | Label for cusp 12 |
+| Setting                  | Type     | Default  | Description                          |
+| ------------------------ | -------- | -------- | ------------------------------------ |
+| `SYMBOL_AS`              | `string` | `'As'`   | Ascendant axis label text            |
+| `SYMBOL_DS`              | `string` | `'Ds'`   | Descendant axis label text           |
+| `SYMBOL_MC`              | `string` | `'Mc'`   | Midheaven axis label text            |
+| `SYMBOL_IC`              | `string` | `'Ic'`   | Imum Coeli axis label text           |
+| `SYMBOL_AXIS_FONT_COLOR` | `string` | `'#333'` | Color for As/Ds/Mc/Ic labels         |
+| `SYMBOL_AXIS_STROKE`     | `number` | `1.6`    | Stroke width for axis labels         |
+| `CUSPS_STROKE`           | `number` | `1`      | Stroke width for cusp dividing lines |
+| `CUSPS_FONT_COLOR`       | `string` | `'#000'` | Color of cusp number labels          |
+| `SYMBOL_CUSP_1`          | `string` | `'1'`    | Label for cusp 1                     |
+| `SYMBOL_CUSP_2`          | `string` | `'2'`    | Label for cusp 2                     |
+| `SYMBOL_CUSP_3`          | `string` | `'3'`    | Label for cusp 3                     |
+| `SYMBOL_CUSP_4`          | `string` | `'4'`    | Label for cusp 4                     |
+| `SYMBOL_CUSP_5`          | `string` | `'5'`    | Label for cusp 5                     |
+| `SYMBOL_CUSP_6`          | `string` | `'6'`    | Label for cusp 6                     |
+| `SYMBOL_CUSP_7`          | `string` | `'7'`    | Label for cusp 7                     |
+| `SYMBOL_CUSP_8`          | `string` | `'8'`    | Label for cusp 8                     |
+| `SYMBOL_CUSP_9`          | `string` | `'9'`    | Label for cusp 9                     |
+| `SYMBOL_CUSP_10`         | `string` | `'10'`   | Label for cusp 10                    |
+| `SYMBOL_CUSP_11`         | `string` | `'11'`   | Label for cusp 11                    |
+| `SYMBOL_CUSP_12`         | `string` | `'12'`   | Label for cusp 12                    |
 
 ---
 
@@ -106,44 +108,44 @@ const chart = new Chart('chart', 600, 600, { /* settings here */ })
 
 These settings control which key name is used to look up each symbol in the built-in symbol renderer. Changing them only makes sense if you have custom symbol definitions that use different keys.
 
-| Setting | Type | Default |
-|---------|------|---------|
-| `SYMBOL_SUN` | `string` | `'Sun'` |
-| `SYMBOL_MOON` | `string` | `'Moon'` |
-| `SYMBOL_MERCURY` | `string` | `'Mercury'` |
-| `SYMBOL_VENUS` | `string` | `'Venus'` |
-| `SYMBOL_MARS` | `string` | `'Mars'` |
-| `SYMBOL_JUPITER` | `string` | `'Jupiter'` |
-| `SYMBOL_SATURN` | `string` | `'Saturn'` |
-| `SYMBOL_URANUS` | `string` | `'Uranus'` |
-| `SYMBOL_NEPTUNE` | `string` | `'Neptune'` |
-| `SYMBOL_PLUTO` | `string` | `'Pluto'` |
-| `SYMBOL_CHIRON` | `string` | `'Chiron'` |
-| `SYMBOL_LILITH` | `string` | `'Lilith'` |
-| `SYMBOL_NNODE` | `string` | `'NNode'` |
-| `SYMBOL_SNODE` | `string` | `'SNode'` |
-| `SYMBOL_FORTUNE` | `string` | `'Fortune'` |
-| `SYMBOL_ARIES` | `string` | `'Aries'` |
-| `SYMBOL_TAURUS` | `string` | `'Taurus'` |
-| `SYMBOL_GEMINI` | `string` | `'Gemini'` |
-| `SYMBOL_CANCER` | `string` | `'Cancer'` |
-| `SYMBOL_LEO` | `string` | `'Leo'` |
-| `SYMBOL_VIRGO` | `string` | `'Virgo'` |
-| `SYMBOL_LIBRA` | `string` | `'Libra'` |
-| `SYMBOL_SCORPIO` | `string` | `'Scorpio'` |
-| `SYMBOL_SAGITTARIUS` | `string` | `'Sagittarius'` |
-| `SYMBOL_CAPRICORN` | `string` | `'Capricorn'` |
-| `SYMBOL_AQUARIUS` | `string` | `'Aquarius'` |
-| `SYMBOL_PISCES` | `string` | `'Pisces'` |
-| `SYMBOL_SIGNS` | `string[]` | `['Aries', 'Taurus', ..., 'Pisces']` |
+| Setting              | Type       | Default                              |
+| -------------------- | ---------- | ------------------------------------ |
+| `SYMBOL_SUN`         | `string`   | `'Sun'`                              |
+| `SYMBOL_MOON`        | `string`   | `'Moon'`                             |
+| `SYMBOL_MERCURY`     | `string`   | `'Mercury'`                          |
+| `SYMBOL_VENUS`       | `string`   | `'Venus'`                            |
+| `SYMBOL_MARS`        | `string`   | `'Mars'`                             |
+| `SYMBOL_JUPITER`     | `string`   | `'Jupiter'`                          |
+| `SYMBOL_SATURN`      | `string`   | `'Saturn'`                           |
+| `SYMBOL_URANUS`      | `string`   | `'Uranus'`                           |
+| `SYMBOL_NEPTUNE`     | `string`   | `'Neptune'`                          |
+| `SYMBOL_PLUTO`       | `string`   | `'Pluto'`                            |
+| `SYMBOL_CHIRON`      | `string`   | `'Chiron'`                           |
+| `SYMBOL_LILITH`      | `string`   | `'Lilith'`                           |
+| `SYMBOL_NNODE`       | `string`   | `'NNode'`                            |
+| `SYMBOL_SNODE`       | `string`   | `'SNode'`                            |
+| `SYMBOL_FORTUNE`     | `string`   | `'Fortune'`                          |
+| `SYMBOL_ARIES`       | `string`   | `'Aries'`                            |
+| `SYMBOL_TAURUS`      | `string`   | `'Taurus'`                           |
+| `SYMBOL_GEMINI`      | `string`   | `'Gemini'`                           |
+| `SYMBOL_CANCER`      | `string`   | `'Cancer'`                           |
+| `SYMBOL_LEO`         | `string`   | `'Leo'`                              |
+| `SYMBOL_VIRGO`       | `string`   | `'Virgo'`                            |
+| `SYMBOL_LIBRA`       | `string`   | `'Libra'`                            |
+| `SYMBOL_SCORPIO`     | `string`   | `'Scorpio'`                          |
+| `SYMBOL_SAGITTARIUS` | `string`   | `'Sagittarius'`                      |
+| `SYMBOL_CAPRICORN`   | `string`   | `'Capricorn'`                        |
+| `SYMBOL_AQUARIUS`    | `string`   | `'Aquarius'`                         |
+| `SYMBOL_PISCES`      | `string`   | `'Pisces'`                           |
+| `SYMBOL_SIGNS`       | `string[]` | `['Aries', 'Taurus', ..., 'Pisces']` |
 
 ---
 
 ## Custom Symbols
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `CUSTOM_SYMBOL_FN` | `((name: string, x: number, y: number, context: SVG) => Element) \| null` | `null` | Custom symbol renderer. Return a valid SVG `Element`, or `null`/`undefined` to fall back to the built-in symbol for that name. |
+| Setting            | Type                                                                      | Default | Description                                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `CUSTOM_SYMBOL_FN` | `((name: string, x: number, y: number, context: SVG) => Element) \| null` | `null`  | Custom symbol renderer. Return a valid SVG `Element`, or `null`/`undefined` to fall back to the built-in symbol for that name. |
 
 See the [Custom Symbols guide](../guides/custom-symbols) for full examples.
 
@@ -151,9 +153,9 @@ See the [Custom Symbols guide](../guides/custom-symbols) for full examples.
 
 ## Aspects
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `ASPECTS` | `Record<string, { degree: number, orbit: number, color: string }>` | *(see below)* | Aspect definitions. Each key is an aspect name; the value defines its degree, allowed orb, and line color. |
+| Setting   | Type                                                               | Default       | Description                                                                                                |
+| --------- | ------------------------------------------------------------------ | ------------- | ---------------------------------------------------------------------------------------------------------- |
+| `ASPECTS` | `Record<string, { degree: number, orbit: number, color: string }>` | _(see below)_ | Aspect definitions. Each key is an aspect name; the value defines its degree, allowed orb, and line color. |
 
 Default value:
 
@@ -171,12 +173,12 @@ You can add any custom aspects — for example, a sextile:
 ```javascript
 const chart = new Chart('chart', 600, 600, {
   ASPECTS: {
-    conjunction: { degree: 0,   orbit: 10, color: 'transparent' },
-    sextile:     { degree: 60,  orbit: 6,  color: '#3498db' },
-    square:      { degree: 90,  orbit: 8,  color: '#FF4500' },
-    trine:       { degree: 120, orbit: 8,  color: '#27AE60' },
-    opposition:  { degree: 180, orbit: 10, color: '#27AE60' }
-  }
+    conjunction: { degree: 0, orbit: 10, color: 'transparent' },
+    sextile: { degree: 60, orbit: 6, color: '#3498db' },
+    square: { degree: 90, orbit: 8, color: '#FF4500' },
+    trine: { degree: 120, orbit: 8, color: '#27AE60' },
+    opposition: { degree: 180, orbit: 10, color: '#27AE60' },
+  },
 })
 ```
 
@@ -184,28 +186,40 @@ const chart = new Chart('chart', 600, 600, {
 
 ## Dignities
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `SHOW_DIGNITIES_TEXT` | `boolean` | `true` | Show dignity labels next to planet symbols |
-| `DIGNITIES_RULERSHIP` | `string` | `'r'` | Label shown when a planet is in its rulership sign |
-| `DIGNITIES_DETRIMENT` | `string` | `'d'` | Label shown when a planet is in detriment |
-| `DIGNITIES_EXALTATION` | `string` | `'e'` | Label shown when a planet is in exaltation |
-| `DIGNITIES_EXACT_EXALTATION` | `string` | `'E'` | Label shown when a planet is at its exact degree of exaltation |
-| `DIGNITIES_FALL` | `string` | `'f'` | Label shown when a planet is in fall |
-| `DIGNITIES_EXACT_EXALTATION_DEFAULT` | `Dignity[]` | *(Crowley positions)* | Array of `{ name, position, orbit }` defining exact exaltation degrees |
+Planet dignities are traditional astrological strength indicators. When `SHOW_DIGNITIES_TEXT` is `true` (the default), a small letter is rendered next to each planet symbol.
+
+| Letter (default) | Dignity          | Meaning                                                                   |
+| ---------------- | ---------------- | ------------------------------------------------------------------------- |
+| `r`              | Rulership        | The planet rules this sign — strongest position.                          |
+| `d`              | Detriment        | The planet is in the opposite sign of its rulership — weakened position.  |
+| `e`              | Exaltation       | The planet is in its exalted sign — elevated strength.                    |
+| `E`              | Exact exaltation | The planet is at its precise degree of exaltation.                        |
+| `f`              | Fall             | The planet is in the opposite sign of its exaltation — weakened position. |
+
+All dignity labels are configurable. Set `SHOW_DIGNITIES_TEXT` to `false` to hide them entirely.
+
+| Setting                              | Type        | Default               | Description                                                            |
+| ------------------------------------ | ----------- | --------------------- | ---------------------------------------------------------------------- |
+| `SHOW_DIGNITIES_TEXT`                | `boolean`   | `true`                | Show dignity labels next to planet symbols                             |
+| `DIGNITIES_RULERSHIP`                | `string`    | `'r'`                 | Label shown when a planet is in its rulership sign                     |
+| `DIGNITIES_DETRIMENT`                | `string`    | `'d'`                 | Label shown when a planet is in detriment                              |
+| `DIGNITIES_EXALTATION`               | `string`    | `'e'`                 | Label shown when a planet is in exaltation                             |
+| `DIGNITIES_EXACT_EXALTATION`         | `string`    | `'E'`                 | Label shown when a planet is at its exact degree of exaltation         |
+| `DIGNITIES_FALL`                     | `string`    | `'f'`                 | Label shown when a planet is in fall                                   |
+| `DIGNITIES_EXACT_EXALTATION_DEFAULT` | `Dignity[]` | _(Crowley positions)_ | Array of `{ name, position, orbit }` defining exact exaltation degrees |
 
 Default `DIGNITIES_EXACT_EXALTATION_DEFAULT`:
 
 ```javascript
-[
-  { name: 'Sun',     position: 19,  orbit: 2 }, // 19° Aries
-  { name: 'Moon',    position: 33,  orbit: 2 }, // 3° Taurus
+;[
+  { name: 'Sun', position: 19, orbit: 2 }, // 19° Aries
+  { name: 'Moon', position: 33, orbit: 2 }, // 3° Taurus
   { name: 'Mercury', position: 155, orbit: 2 }, // 15° Virgo
-  { name: 'Venus',   position: 357, orbit: 2 }, // 27° Pisces
-  { name: 'Mars',    position: 298, orbit: 2 }, // 28° Capricorn
+  { name: 'Venus', position: 357, orbit: 2 }, // 27° Pisces
+  { name: 'Mars', position: 298, orbit: 2 }, // 28° Capricorn
   { name: 'Jupiter', position: 105, orbit: 2 }, // 15° Cancer
-  { name: 'Saturn',  position: 201, orbit: 2 }, // 21° Libra
-  { name: 'NNode',   position: 63,  orbit: 2 }, // 3° Gemini
+  { name: 'Saturn', position: 201, orbit: 2 }, // 21° Libra
+  { name: 'NNode', position: 63, orbit: 2 }, // 3° Gemini
 ]
 ```
 
@@ -213,9 +227,9 @@ Default `DIGNITIES_EXACT_EXALTATION_DEFAULT`:
 
 ## Animation
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `ANIMATION_CUSPS_ROTATION_SPEED` | `number` | `2` | Speed of the transit cusps rotation animation. Valid range: `0`–`4`. |
+| Setting                          | Type     | Default | Description                                                          |
+| -------------------------------- | -------- | ------- | -------------------------------------------------------------------- |
+| `ANIMATION_CUSPS_ROTATION_SPEED` | `number` | `2`     | Speed of the transit cusps rotation animation. Valid range: `0`–`4`. |
 
 ---
 
@@ -223,19 +237,19 @@ Default `DIGNITIES_EXACT_EXALTATION_DEFAULT`:
 
 These settings control the `id` attributes applied to SVG group elements inside the chart. **You should not change these unless you have a specific reason** (e.g. avoiding conflicts with other SVG elements on the page).
 
-| Setting | Default |
-|---------|---------|
-| `ID_CHART` | `'astrology'` |
-| `ID_RADIX` | `'radix'` |
-| `ID_TRANSIT` | `'transit'` |
-| `ID_ASPECTS` | `'aspects'` |
-| `ID_POINTS` | `'planets'` |
-| `ID_SIGNS` | `'signs'` |
-| `ID_CIRCLES` | `'circles'` |
-| `ID_AXIS` | `'axis'` |
-| `ID_CUSPS` | `'cusps'` |
-| `ID_RULER` | `'ruler'` |
-| `ID_BG` | `'bg'` |
+| Setting      | Default       |
+| ------------ | ------------- |
+| `ID_CHART`   | `'astrology'` |
+| `ID_RADIX`   | `'radix'`     |
+| `ID_TRANSIT` | `'transit'`   |
+| `ID_ASPECTS` | `'aspects'`   |
+| `ID_POINTS`  | `'planets'`   |
+| `ID_SIGNS`   | `'signs'`     |
+| `ID_CIRCLES` | `'circles'`   |
+| `ID_AXIS`    | `'axis'`      |
+| `ID_CUSPS`   | `'cusps'`     |
+| `ID_RULER`   | `'ruler'`     |
+| `ID_BG`      | `'bg'`        |
 
 ---
 

--- a/website/src/content/docs/guides/custom-settings.md
+++ b/website/src/content/docs/guides/custom-settings.md
@@ -25,86 +25,87 @@ const radix = chart.radix(data)
 
 ### Colors
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `COLOR_BACKGROUND` | `string` | `'#fff'` | SVG background fill color |
-| `POINTS_COLOR` | `string` | `'#000'` | Color of planet symbols |
-| `SIGNS_COLOR` | `string` | `'#000'` | Color of zodiac sign symbols |
-| `CIRCLE_COLOR` | `string` | `'#333'` | Color of chart ring circles |
-| `LINE_COLOR` | `string` | `'#333'` | Color of spoke/house lines |
-| `SYMBOL_AXIS_FONT_COLOR` | `string` | `'#333'` | Color of As/Ds/Mc/Ic labels |
-| `CUSPS_FONT_COLOR` | `string` | `'#000'` | Color of cusp number labels |
-| `COLOR_ARIES` | `string` | `'#FF4500'` | Sign sector color — Aries |
-| `COLOR_TAURUS` | `string` | `'#8B4513'` | Sign sector color — Taurus |
-| `COLOR_GEMINI` | `string` | `'#87CEEB'` | Sign sector color — Gemini |
-| `COLOR_CANCER` | `string` | `'#27AE60'` | Sign sector color — Cancer |
-| `COLOR_LEO` | `string` | `'#FF4500'` | Sign sector color — Leo |
-| `COLOR_VIRGO` | `string` | `'#8B4513'` | Sign sector color — Virgo |
-| `COLOR_LIBRA` | `string` | `'#87CEEB'` | Sign sector color — Libra |
-| `COLOR_SCORPIO` | `string` | `'#27AE60'` | Sign sector color — Scorpio |
-| `COLOR_SAGITTARIUS` | `string` | `'#FF4500'` | Sign sector color — Sagittarius |
-| `COLOR_CAPRICORN` | `string` | `'#8B4513'` | Sign sector color — Capricorn |
-| `COLOR_AQUARIUS` | `string` | `'#87CEEB'` | Sign sector color — Aquarius |
-| `COLOR_PISCES` | `string` | `'#27AE60'` | Sign sector color — Pisces |
-| `COLORS_SIGNS` | `string[]` | *(array of the 12 above)* | Ordered array of all 12 sign colors |
+| Setting                  | Type       | Default                   | Description                         |
+| ------------------------ | ---------- | ------------------------- | ----------------------------------- |
+| `COLOR_BACKGROUND`       | `string`   | `'#fff'`                  | SVG background fill color           |
+| `POINTS_COLOR`           | `string`   | `'#000'`                  | Color of planet symbols             |
+| `SIGNS_COLOR`            | `string`   | `'#000'`                  | Color of zodiac sign symbols        |
+| `CIRCLE_COLOR`           | `string`   | `'#333'`                  | Color of chart ring circles         |
+| `LINE_COLOR`             | `string`   | `'#333'`                  | Color of spoke/house lines          |
+| `SYMBOL_AXIS_FONT_COLOR` | `string`   | `'#333'`                  | Color of As/Ds/Mc/Ic labels         |
+| `CUSPS_FONT_COLOR`       | `string`   | `'#000'`                  | Color of cusp number labels         |
+| `COLOR_ARIES`            | `string`   | `'#FF4500'`               | Sign sector color — Aries           |
+| `COLOR_TAURUS`           | `string`   | `'#8B4513'`               | Sign sector color — Taurus          |
+| `COLOR_GEMINI`           | `string`   | `'#87CEEB'`               | Sign sector color — Gemini          |
+| `COLOR_CANCER`           | `string`   | `'#27AE60'`               | Sign sector color — Cancer          |
+| `COLOR_LEO`              | `string`   | `'#FF4500'`               | Sign sector color — Leo             |
+| `COLOR_VIRGO`            | `string`   | `'#8B4513'`               | Sign sector color — Virgo           |
+| `COLOR_LIBRA`            | `string`   | `'#87CEEB'`               | Sign sector color — Libra           |
+| `COLOR_SCORPIO`          | `string`   | `'#27AE60'`               | Sign sector color — Scorpio         |
+| `COLOR_SAGITTARIUS`      | `string`   | `'#FF4500'`               | Sign sector color — Sagittarius     |
+| `COLOR_CAPRICORN`        | `string`   | `'#8B4513'`               | Sign sector color — Capricorn       |
+| `COLOR_AQUARIUS`         | `string`   | `'#87CEEB'`               | Sign sector color — Aquarius        |
+| `COLOR_PISCES`           | `string`   | `'#27AE60'`               | Sign sector color — Pisces          |
+| `COLORS_SIGNS`           | `string[]` | _(array of the 12 above)_ | Ordered array of all 12 sign colors |
 
 ### Symbols
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `SYMBOL_SCALE` | `number` | `1` | Global scale factor for all symbols |
-| `SYMBOL_SUN` | `string` | `'Sun'` | Key name for Sun symbol |
-| `SYMBOL_MOON` | `string` | `'Moon'` | Key name for Moon symbol |
-| `SYMBOL_MERCURY` | `string` | `'Mercury'` | Key name for Mercury symbol |
-| `SYMBOL_VENUS` | `string` | `'Venus'` | Key name for Venus symbol |
-| `SYMBOL_MARS` | `string` | `'Mars'` | Key name for Mars symbol |
-| `SYMBOL_JUPITER` | `string` | `'Jupiter'` | Key name for Jupiter symbol |
-| `SYMBOL_SATURN` | `string` | `'Saturn'` | Key name for Saturn symbol |
-| `SYMBOL_URANUS` | `string` | `'Uranus'` | Key name for Uranus symbol |
-| `SYMBOL_NEPTUNE` | `string` | `'Neptune'` | Key name for Neptune symbol |
-| `SYMBOL_PLUTO` | `string` | `'Pluto'` | Key name for Pluto symbol |
-| `SYMBOL_CHIRON` | `string` | `'Chiron'` | Key name for Chiron symbol |
-| `SYMBOL_LILITH` | `string` | `'Lilith'` | Key name for Lilith symbol |
-| `SYMBOL_NNODE` | `string` | `'NNode'` | Key name for North Node symbol |
-| `SYMBOL_SNODE` | `string` | `'SNode'` | Key name for South Node symbol |
-| `SYMBOL_FORTUNE` | `string` | `'Fortune'` | Key name for Part of Fortune symbol |
-| `SYMBOL_AS` | `string` | `'As'` | Ascendant axis label |
-| `SYMBOL_DS` | `string` | `'Ds'` | Descendant axis label |
-| `SYMBOL_MC` | `string` | `'Mc'` | Midheaven axis label |
-| `SYMBOL_IC` | `string` | `'Ic'` | Imum Coeli axis label |
-| `SYMBOL_SIGNS` | `string[]` | *(all 12 sign names)* | Ordered array of sign name keys |
-| `CUSTOM_SYMBOL_FN` | `function \| null` | `null` | Custom symbol renderer — see [Custom Symbols](./custom-symbols) |
+| Setting            | Type               | Default               | Description                                                     |
+| ------------------ | ------------------ | --------------------- | --------------------------------------------------------------- |
+| `SYMBOL_SCALE`     | `number`           | `1`                   | Global scale factor for all symbols                             |
+| `SYMBOL_SUN`       | `string`           | `'Sun'`               | Key name for Sun symbol                                         |
+| `SYMBOL_MOON`      | `string`           | `'Moon'`              | Key name for Moon symbol                                        |
+| `SYMBOL_MERCURY`   | `string`           | `'Mercury'`           | Key name for Mercury symbol                                     |
+| `SYMBOL_VENUS`     | `string`           | `'Venus'`             | Key name for Venus symbol                                       |
+| `SYMBOL_MARS`      | `string`           | `'Mars'`              | Key name for Mars symbol                                        |
+| `SYMBOL_JUPITER`   | `string`           | `'Jupiter'`           | Key name for Jupiter symbol                                     |
+| `SYMBOL_SATURN`    | `string`           | `'Saturn'`            | Key name for Saturn symbol                                      |
+| `SYMBOL_URANUS`    | `string`           | `'Uranus'`            | Key name for Uranus symbol                                      |
+| `SYMBOL_NEPTUNE`   | `string`           | `'Neptune'`           | Key name for Neptune symbol                                     |
+| `SYMBOL_PLUTO`     | `string`           | `'Pluto'`             | Key name for Pluto symbol                                       |
+| `SYMBOL_CHIRON`    | `string`           | `'Chiron'`            | Key name for Chiron symbol                                      |
+| `SYMBOL_LILITH`    | `string`           | `'Lilith'`            | Key name for Lilith symbol                                      |
+| `SYMBOL_NNODE`     | `string`           | `'NNode'`             | Key name for North Node symbol                                  |
+| `SYMBOL_SNODE`     | `string`           | `'SNode'`             | Key name for South Node symbol                                  |
+| `SYMBOL_FORTUNE`   | `string`           | `'Fortune'`           | Key name for Part of Fortune symbol                             |
+| `SYMBOL_AS`        | `string`           | `'As'`                | Ascendant axis label                                            |
+| `SYMBOL_DS`        | `string`           | `'Ds'`                | Descendant axis label                                           |
+| `SYMBOL_MC`        | `string`           | `'Mc'`                | Midheaven axis label                                            |
+| `SYMBOL_IC`        | `string`           | `'Ic'`                | Imum Coeli axis label                                           |
+| `SYMBOL_SIGNS`     | `string[]`         | _(all 12 sign names)_ | Ordered array of sign name keys                                 |
+| `CUSTOM_SYMBOL_FN` | `function \| null` | `null`                | Custom symbol renderer — see [Custom Symbols](./custom-symbols) |
 
 ### Geometry
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `MARGIN` | `number` | `50` | Outer margin in px |
-| `PADDING` | `number` | `18` | Inner padding in px |
-| `SHIFT_IN_DEGREES` | `number` | `180` | Chart rotation offset (0° = West) |
-| `INDOOR_CIRCLE_RADIUS_RATIO` | `number` | `2` | Divisor for inner-most circle radius |
-| `INNER_CIRCLE_RADIUS_RATIO` | `number` | `8` | Divisor for planet ring inner edge |
-| `RULER_RADIUS` | `number` | `4` | Divisor for degree ruler band width |
-| `COLLISION_RADIUS` | `number` | `10` | Planet collision avoidance radius (px) at scale 1 |
+| Setting                      | Type     | Default | Description                                       |
+| ---------------------------- | -------- | ------- | ------------------------------------------------- |
+| `MARGIN`                     | `number` | `50`    | Outer margin in px                                |
+| `PADDING`                    | `number` | `18`    | Inner padding in px                               |
+| `SHIFT_IN_DEGREES`           | `number` | `180`   | Chart rotation offset (0° = West)                 |
+| `INDOOR_CIRCLE_RADIUS_RATIO` | `number` | `2`     | Divisor for inner-most circle radius              |
+| `INNER_CIRCLE_RADIUS_RATIO`  | `number` | `8`     | Divisor for planet ring inner edge                |
+| `RULER_RADIUS`               | `number` | `4`     | Divisor for degree ruler band width               |
+| `COLLISION_RADIUS`           | `number` | `10`    | Planet collision avoidance radius (px) at scale 1 |
 
 ### Stroke & Lines
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `POINTS_STROKE` | `number` | `1.8` | Stroke width for planet symbols |
-| `SIGNS_STROKE` | `number` | `1.5` | Stroke width for sign symbols |
-| `CIRCLE_STRONG` | `number` | `2` | Stroke width for circles |
-| `SYMBOL_AXIS_STROKE` | `number` | `1.6` | Stroke width for axis labels |
-| `CUSPS_STROKE` | `number` | `1` | Stroke width for cusp lines |
-| `STROKE_ONLY` | `boolean` | `false` | Render all symbols as outlines only (no fill) |
+| Setting              | Type      | Default | Description                                   |
+| -------------------- | --------- | ------- | --------------------------------------------- |
+| `POINTS_STROKE`      | `number`  | `1.8`   | Stroke width for planet symbols               |
+| `SIGNS_STROKE`       | `number`  | `1.5`   | Stroke width for sign symbols                 |
+| `CIRCLE_STRONG`      | `number`  | `2`     | Stroke width for circles                      |
+| `SYMBOL_AXIS_STROKE` | `number`  | `1.6`   | Stroke width for axis labels                  |
+| `CUSPS_STROKE`       | `number`  | `1`     | Stroke width for cusp lines                   |
+| `STROKE_ONLY`        | `boolean` | `false` | Render all symbols as outlines only (no fill) |
 
 ### Aspects
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `ASPECTS` | `Aspect` | *(see below)* | Aspect definitions — degree, orbit, and color |
+| Setting   | Type     | Default       | Description                                   |
+| --------- | -------- | ------------- | --------------------------------------------- |
+| `ASPECTS` | `Aspect` | _(see below)_ | Aspect definitions — degree, orbit, and color |
 
 Default `ASPECTS` value:
+
 ```javascript
 {
   conjunction: { degree: 0,   orbit: 10, color: 'transparent' },
@@ -116,32 +117,53 @@ Default `ASPECTS` value:
 
 ### Dignities
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `SHOW_DIGNITIES_TEXT` | `boolean` | `true` | Show dignity labels next to planets |
-| `DIGNITIES_RULERSHIP` | `string` | `'r'` | Label for rulership dignity |
-| `DIGNITIES_DETRIMENT` | `string` | `'d'` | Label for detriment |
-| `DIGNITIES_EXALTATION` | `string` | `'e'` | Label for exaltation |
-| `DIGNITIES_EXACT_EXALTATION` | `string` | `'E'` | Label for exact exaltation |
-| `DIGNITIES_FALL` | `string` | `'f'` | Label for fall |
-| `DIGNITIES_EXACT_EXALTATION_DEFAULT` | `Dignity[]` | *(Crowley positions)* | Exact exaltation positions |
+| Setting                              | Type        | Default               | Description                         |
+| ------------------------------------ | ----------- | --------------------- | ----------------------------------- |
+| `SHOW_DIGNITIES_TEXT`                | `boolean`   | `true`                | Show dignity labels next to planets |
+| `DIGNITIES_RULERSHIP`                | `string`    | `'r'`                 | Label for rulership dignity         |
+| `DIGNITIES_DETRIMENT`                | `string`    | `'d'`                 | Label for detriment                 |
+| `DIGNITIES_EXALTATION`               | `string`    | `'e'`                 | Label for exaltation                |
+| `DIGNITIES_EXACT_EXALTATION`         | `string`    | `'E'`                 | Label for exact exaltation          |
+| `DIGNITIES_FALL`                     | `string`    | `'f'`                 | Label for fall                      |
+| `DIGNITIES_EXACT_EXALTATION_DEFAULT` | `Dignity[]` | _(Crowley positions)_ | Exact exaltation positions          |
+
+You can hide dignity labels completely or customize the displayed abbreviations.
+
+#### Hide dignity labels entirely
+
+```javascript
+const chart = new Chart('chart', 600, 600, {
+  SHOW_DIGNITIES_TEXT: false,
+})
+```
+
+#### Use different abbreviations
+
+```javascript
+const chart = new Chart('chart', 600, 600, {
+  DIGNITIES_RULERSHIP: 'rul',
+  DIGNITIES_DETRIMENT: 'det',
+  DIGNITIES_EXALTATION: 'exalt',
+  DIGNITIES_FALL: 'fall',
+})
+```
 
 ### Animation
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `ANIMATION_CUSPS_ROTATION_SPEED` | `number` | `2` | Transit rotation animation speed (0–4) |
+| Setting                          | Type     | Default | Description                            |
+| -------------------------------- | -------- | ------- | -------------------------------------- |
+| `ANIMATION_CUSPS_ROTATION_SPEED` | `number` | `2`     | Transit rotation animation speed (0–4) |
 
 ### Interaction
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
+| Setting          | Type      | Default | Description                                |
+| ---------------- | --------- | ------- | ------------------------------------------ |
 | `ADD_CLICK_AREA` | `boolean` | `false` | Enable click-event areas on chart elements |
 
 ### Debug
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
+| Setting | Type      | Default | Description                                   |
+| ------- | --------- | ------- | --------------------------------------------- |
 | `DEBUG` | `boolean` | `false` | Log internal debug information to the console |
 
 ---
@@ -173,13 +195,13 @@ const darkSettings = {
   COLOR_CAPRICORN: '#664411',
   COLOR_AQUARIUS: '#336699',
   COLOR_PISCES: '#1e7a4a',
-  COLORS_SIGNS: ['#cc3300','#664411','#336699','#1e7a4a','#cc3300','#664411','#336699','#1e7a4a','#cc3300','#664411','#336699','#1e7a4a'],
+  COLORS_SIGNS: ['#cc3300', '#664411', '#336699', '#1e7a4a', '#cc3300', '#664411', '#336699', '#1e7a4a', '#cc3300', '#664411', '#336699', '#1e7a4a'],
   ASPECTS: {
-    conjunction: { degree: 0,   orbit: 10, color: 'transparent' },
-    square:      { degree: 90,  orbit: 8,  color: '#ff6633' },
-    trine:       { degree: 120, orbit: 8,  color: '#33cc77' },
-    opposition:  { degree: 180, orbit: 10, color: '#6699ff' }
-  }
+    conjunction: { degree: 0, orbit: 10, color: 'transparent' },
+    square: { degree: 90, orbit: 8, color: '#ff6633' },
+    trine: { degree: 120, orbit: 8, color: '#33cc77' },
+    opposition: { degree: 180, orbit: 10, color: '#6699ff' },
+  },
 }
 
 const chart = new Chart('chart', 600, 600, darkSettings)
@@ -202,11 +224,11 @@ Override just the aspect colors without touching any other settings:
 ```javascript
 const chart = new Chart('chart', 600, 600, {
   ASPECTS: {
-    conjunction: { degree: 0,   orbit: 10, color: '#9b59b6' },
-    square:      { degree: 90,  orbit: 8,  color: '#e74c3c' },
-    trine:       { degree: 120, orbit: 8,  color: '#2ecc71' },
-    opposition:  { degree: 180, orbit: 10, color: '#3498db' }
-  }
+    conjunction: { degree: 0, orbit: 10, color: '#9b59b6' },
+    square: { degree: 90, orbit: 8, color: '#e74c3c' },
+    trine: { degree: 120, orbit: 8, color: '#2ecc71' },
+    opposition: { degree: 180, orbit: 10, color: '#3498db' },
+  },
 })
 chart.radix(data)
 ```

--- a/website/src/content/docs/guides/transit-chart.mdx
+++ b/website/src/content/docs/guides/transit-chart.mdx
@@ -10,6 +10,7 @@ import ChartDemo from '../../../components/ChartDemo.astro'
 A **transit chart** overlays the **current** positions of planets over your **natal (radix) chart**. This shows how transiting planets are affecting your birth chart right now.
 
 Transit charts are useful for:
+
 - Seeing current planetary activity relative to your birth chart
 - Identifying aspects between transit and natal planets
 - Tracking planetary transits over time
@@ -25,25 +26,24 @@ import { Chart } from '@astrodraw/astrochart'
 // Your natal chart data
 const radixData = {
   planets: {
-    Sun:  [12.45, 0],
+    Sun: [12.45, 0],
     Moon: [145.67, 0],
     Mercury: [8.23, 0],
     Venus: [35.12, 0],
-    Mars: [162.34, 0]
+    Mars: [162.34, 0],
   },
-  cusps: [315.45, 35.67, 65.23, 92.45, 125.67, 155.89,
-          135.45, 215.67, 245.23, 272.45, 305.67, 335.89]
+  cusps: [315.45, 35.67, 65.23, 92.45, 125.67, 155.89, 135.45, 215.67, 245.23, 272.45, 305.67, 335.89],
 }
 
 // Current planetary positions (transit data)
 const transitData = {
   planets: {
-    Sun:  [155.67, 0],   // current Sun position
-    Moon: [245.23, 0],   // current Moon position
+    Sun: [155.67, 0], // current Sun position
+    Moon: [245.23, 0], // current Moon position
     Mercury: [122.34, 0],
     Venus: [198.56, 0],
-    Mars: [310.78, 0]
-  }
+    Mars: [310.78, 0],
+  },
 }
 
 const chart = new Chart('chart', 600, 600)
@@ -53,10 +53,16 @@ chart.radix(radixData).transit(transitData)
 ## How Transits Are Rendered
 
 When you call `.transit()`, AstroChart renders:
+
 - The **inner ring** shows your natal (radix) planets
 - The **outer ring** shows the transit planets
 - The **houses** and **aspects** remain from the natal chart
 - Transit-to-natal aspects can be calculated automatically
+
+### Planet Dignities
+
+When `SHOW_DIGNITIES_TEXT` is enabled (default), transit planets display the same dignity labels as radix planets.
+The displayed label reflects the transiting planet's current sign position.
 
 ## Full Example with Multiple Planets
 
@@ -67,36 +73,35 @@ import { Chart } from '@astrodraw/astrochart'
 
 const radixData = {
   planets: {
-    Sun:     [12.45, 0],
-    Moon:    [145.67, 0],
+    Sun: [12.45, 0],
+    Moon: [145.67, 0],
     Mercury: [8.23, 0],
-    Venus:   [35.12, 0],
-    Mars:    [162.34, 0],
+    Venus: [35.12, 0],
+    Mars: [162.34, 0],
     Jupiter: [298.56, 0],
-    Saturn:  [245.78, 0],
-    Uranus:  [178.90, 0],
+    Saturn: [245.78, 0],
+    Uranus: [178.9, 0],
     Neptune: [210.12, 0],
-    Pluto:   [238.34, 0],
-    NNode:   [95.45, 0]
+    Pluto: [238.34, 0],
+    NNode: [95.45, 0],
   },
-  cusps: [315.45, 35.67, 65.23, 92.45, 125.67, 155.89,
-          135.45, 215.67, 245.23, 272.45, 305.67, 335.89]
+  cusps: [315.45, 35.67, 65.23, 92.45, 125.67, 155.89, 135.45, 215.67, 245.23, 272.45, 305.67, 335.89],
 }
 
 const transitData = {
   planets: {
-    Sun:     [155.67, 0],   // Sun has moved 143.22°
-    Moon:    [245.23, 0],   // Moon has moved 99.56°
+    Sun: [155.67, 0], // Sun has moved 143.22°
+    Moon: [245.23, 0], // Moon has moved 99.56°
     Mercury: [122.34, 0],
-    Venus:   [198.56, 0],
-    Mars:    [310.78, 0],
+    Venus: [198.56, 0],
+    Mars: [310.78, 0],
     Jupiter: [15.67, 0],
-    Saturn:  [288.90, 0],
-    Uranus:  [205.12, 0],
+    Saturn: [288.9, 0],
+    Uranus: [205.12, 0],
     Neptune: [245.34, 0],
-    Pluto:   [275.67, 0],
-    NNode:   [85.45, 0]
-  }
+    Pluto: [275.67, 0],
+    NNode: [85.45, 0],
+  },
 }
 
 const chart = new Chart('chart', 600, 600)
@@ -111,9 +116,9 @@ Transit planets can also be retrograde — pass a negative velocity as the secon
 const transitData = {
   planets: {
     Mercury: [122.34, -1.2], // retrograde transit (negative velocity)
-    Venus:   [198.56, 1.1],  // direct transit (positive velocity)
-    Mars:    [310.78, -0.8]  // retrograde transit (negative velocity)
-  }
+    Venus: [198.56, 1.1], // direct transit (positive velocity)
+    Mars: [310.78, -0.8], // retrograde transit (negative velocity)
+  },
 }
 ```
 
@@ -124,7 +129,7 @@ You can draw transit-to-natal aspects on the chart:
 ```javascript
 const chart = new Chart('chart', 600, 600)
 const transit = chart.radix(radixData).transit(transitData)
-transit.aspects()  // Shows aspects between transit and natal planets
+transit.aspects() // Shows aspects between transit and natal planets
 ```
 
 ## Interactive Demo
@@ -154,11 +159,13 @@ Or use `.animate()` for a smooth animation between transit states (see [Animatio
 Renders a transit ring and returns a `Transit` instance.
 
 **Parameters:**
+
 - `data` — `AstroData` object with transit planets. **Note:** Transit data only needs `planets`; `cusps` are taken from the radix.
 
 **Returns:** `Transit` instance
 
 **Methods on Transit:**
+
 - `aspects()` — Calculate and draw transit-to-natal aspects
 - `animate(data, duration, callback)` — Animate to new transit positions
 - `on(eventName, callback)` — Add click/hover listeners


### PR DESCRIPTION
## Summary

This PR improves the documentation for planetary dignity indicators by:

- adding an explanation of the dignity labels in the Settings Reference
- documenting dignity labels for transit charts
- adding configuration examples to the Custom Settings guide

Closes #118